### PR TITLE
Add sys/resource.h include

### DIFF
--- a/c_src/ei++.h
+++ b/c_src/ei++.h
@@ -51,6 +51,7 @@
 #include <algorithm>
 #include <iostream>
 #include <sys/time.h>
+#include <sys/resource.h>
 #include <limits.h>
 #include <assert.h>
 


### PR DESCRIPTION
erlexec was failing to compile on a  Debian system due to the lack of this include.

Thanks!
