### PR TITLE
Added code to manage an already existing external process.

### DIFF
--- a/c_src/exec.cpp
+++ b/c_src/exec.cpp
@@ -467,7 +467,7 @@ int main(int argc, char* argv[])
 
                     long pid;
                     pid_t realpid;
-                    if (arity != 2 || (eis.decodeInt(pid)) < 0) {
+                    if (arity != 3 || (eis.decodeInt(pid)) < 0 || po.ei_decode(eis) < 0) {
                         send_error_str(transId, true, "badarg");
                         continue;
                     }

--- a/src/exec.erl
+++ b/src/exec.erl
@@ -121,7 +121,7 @@
 
 %% External exports
 -export([
-    start/1, start_link/1, run/2, run_link/2, manage/1,
+    start/1, start_link/1, run/2, run_link/2, manage/2,
     which_children/0, kill/2, stop/1, ospid/1, pid/1, status/1
 ]).
 
@@ -197,10 +197,10 @@ run(Exe, Options) when is_list(Exe), is_list(Options) ->
 %%      the external process.
 %% @end
 %%-------------------------------------------------------------------------
--spec manage(ospid()) ->
+-spec manage(ospid(), Options::cmd_options()) ->
     {ok, pid(), ospid()} | {error, any()}.
-manage(Pid) ->
-    gen_server:call(?MODULE, {port, {manage, Pid}}).
+manage(Pid, Options) ->
+    gen_server:call(?MODULE, {port, {manage, Pid, Options}}).
 
 %%-------------------------------------------------------------------------
 %% @equiv run/2
@@ -571,7 +571,8 @@ is_port_command({stop, Pid}, _State) when is_pid(Pid) ->
     [{Pid, OsPid}]  -> {ok, {stop, OsPid}, undefined};
     []              -> throw({error, no_process})
     end;
-is_port_command({manage, OsPid} = T, _State) when is_integer(OsPid) ->
+is_port_command({manage, OsPid, Options} = T, State) when is_integer(OsPid) ->
+    check_cmd_options(Options, State),
     {ok, T, undefined};
 is_port_command({kill, OsPid, Sig}=T, _State) when is_integer(OsPid),is_integer(Sig) -> 
     {ok, T, undefined};


### PR DESCRIPTION
This code lets erlexec take over management of an existing OS process.  For instance, something started with open_port, or os:cmd, or whatever.
