### PR TITLE
Give kill and stop functions the ability to kill/stop erlang Ports.

### DIFF
--- a/src/exec.erl
+++ b/src/exec.erl
@@ -303,7 +303,7 @@ run_link(Exe, Options) when is_list(Exe), is_list(Options) ->
 %%-------------------------------------------------------------------------
 -spec manage(ospid() | port(), Options::cmd_options()) ->
     {ok, pid(), ospid()} | {error, any()}.
-manage(Pid, Options) ->
+manage(Pid, Options) when is_integer(Pid) ->
     do_run({manage, Pid, Options}, Options);
 manage(Port, Options) when is_port(Port) ->
     {os_pid, OsPid} = erlang:port_info(Port, os_pid),


### PR DESCRIPTION
We use Erlang ports for some things, so it's convenient to be able to kill them directly.
