### PR TITLE
Fix stop_and_wait to handle ports and os_pids correctly

### DIFF
--- a/src/exec.erl
+++ b/src/exec.erl
@@ -360,10 +360,18 @@ stop(Port) when is_port(Port) ->
 %%-------------------------------------------------------------------------
 
 -spec stop_and_wait(pid() | ospid() | port(), integer()) -> term() | {error, any()}.
-stop_and_wait(Pid, Timeout) when is_pid(Pid); is_integer(Pid) ->
+stop_and_wait(Port, Timeout) when is_port(Port) ->
+    {os_pid, OsPid} = erlang:port_info(Port, os_pid),
+    stop_and_wait(Pid, Timeout);
+
+stop_and_wait(OsPid, Timeout) when is_integer(OsPid) ->
+    [{_, Pid}] = ets:lookup(exec_mon, OsPid),
+    stop_and_wait(Pid, Timeout);
+
+stop_and_wait(Pid, Timeout) when is_pid(Pid) ->
     gen_server:call(?MODULE, {port, {stop, Pid}}, Timeout),
     receive
-        {'DOWN', _Ref, process, _Pid, ExitStatus} ->
+        {'DOWN', _Ref, process, Pid, ExitStatus} ->
             ExitStatus
     after Timeout ->
             {error, timeout}


### PR DESCRIPTION
If the Pid passed to stop_and_wait is an os_pid, then it will never
match with the message's Pid.
