### PR TITLE
Fixed non-zero exit code returned to Erlang VM

### DIFF
--- a/c_src/exec.cpp
+++ b/c_src/exec.cpp
@@ -1591,7 +1591,7 @@ int send_pid_status_term(const PidStatusT& stat)
     eis.encodeTupleSize(3);
     eis.encode(atom_t("exit_status"));
     eis.encode(stat.first);
-    eis.encode(stat.second);
+    eis.encode(WEXITSTATUS(stat.second));
     return eis.write();
 }
 


### PR DESCRIPTION
According to http://linux.die.net/man/2/waitpid, WEXITSTATUS() is the correct way to get exit code from a value received from waitpid() function. 

I'm not sure if this is the best place to run WEXITSTATUS(), but I don't understand the code well enough to find a better place :)
