### PR TITLE
Make runtime lookups more resilient

### DIFF
--- a/src/exec.erl
+++ b/src/exec.erl
@@ -540,13 +540,14 @@ default() ->
 
 %% @private
 default(portexe) -> 
-    % Get architecture (e.g. i386-linux)
-    Dir = filename:dirname(filename:dirname(code:which(?MODULE))),
-    Tail = filename:join([erlang:system_info(system_architecture), "exec-port"]),
-    case os:find_executable(filename:join([Dir, "priv", Tail])) of
-        false -> os:find_executable(filename:join([code:priv_dir(erlexec), Tail]));
-        Exe -> Exe
-    end;
+    % Retrieve the Priv directory
+    Priv = code:priv_dir(erlexec),
+    % Find all ports using wildcard for resiliency
+    Ports = filelib:wildcard("*/exec-port", Priv),
+    % Use last found to always get latest version
+    Last = lists:last(Ports),
+    % Join the priv/port path
+    filename:join([Priv, Last]);
 default(Option) ->
     proplists:get_value(Option, default()).
 

--- a/src/exec.erl
+++ b/src/exec.erl
@@ -543,11 +543,15 @@ default(portexe) ->
     % Retrieve the Priv directory
     Priv = code:priv_dir(erlexec),
     % Find all ports using wildcard for resiliency
-    Ports = filelib:wildcard("*/exec-port", Priv),
-    % Use last found to always get latest version
-    Last = lists:last(Ports),
+    Bin = case filelib:wildcard("*/exec-port", Priv) of
+        [Port] -> Port;
+        _      ->
+            Arch = erlang:system_info(system_architecture),
+            Tail = filelibename:join([Arch, "exec-port"]),
+            os:find_executable(filename:join([Priv, Tail]))
+    end,
     % Join the priv/port path
-    filename:join([Priv, Last]);
+    filename:join([Priv, Bin]);
 default(Option) ->
     proplists:get_value(Option, default()).
 


### PR DESCRIPTION
This PR makes the lookup of `exec-port` at runtime more resilient.

This should resolve #82 in a way that doesn't cause an issue with #63. Basically it makes the lookup handle situations where the arch has changed, without just breaking. 

I believe this should also work alongside #84, but I'm not sure? Can't see why not.