### PR TITLE
Fix for 'Can't run from within an escript #92'

### DIFF
--- a/c_src/exec.cpp
+++ b/c_src/exec.cpp
@@ -597,13 +597,12 @@ int finalize(fd_set& readfds)
             FD_ZERO(&readfds);
             FD_SET (sigchld_pipe[0], &readfds); // pipe for delivering SIGCHLD signals
 
-            int ec;
             int maxfd = std::max<int>(eis.read_handle(), sigchld_pipe[0]);
             int cnt;
             while ((cnt = select(maxfd+1, &readfds, NULL, NULL, &ts)) < 0 && errno == EINTR);
 
             if (cnt < 0) {
-                fprintf(stderr, "Error in finalizing pselect(2): %s\r\n", strerror(ec));
+                fprintf(stderr, "Error in finalizing pselect(2): %s\r\n", strerror(errno));
                 break;
             } else if (cnt > 0 && FD_ISSET(sigchld_pipe[0], &readfds) ) {
                 if (!process_sigchld())
@@ -617,4 +616,3 @@ int finalize(fd_set& readfds)
 
     return old_terminated;
 }
-

--- a/src/exec.erl
+++ b/src/exec.erl
@@ -548,23 +548,26 @@ default() ->
      {args, ""},        % Extra arguments that can be passed to port program
      {alarm, 12},
      {user, ""},        % Run port program as this user
-     {limit_users, []}, % Restricted list of users allowed to run commands
-     {portexe, default(portexe)}].
-
+     {limit_users, []}]. % Restricted list of users allowed to run commands
 %% @private
 default(portexe) -> 
     % Retrieve the Priv directory
-    Priv = code:priv_dir(erlexec),
-    % Find all ports using wildcard for resiliency
-    Bin = case filelib:wildcard("*/exec-port", Priv) of
-        [Port] -> Port;
-        _      ->
-            Arch = erlang:system_info(system_architecture),
-            Tail = filename:join([Arch, "exec-port"]),
-            os:find_executable(filename:join([Priv, Tail]))
-    end,
-    % Join the priv/port path
-    filename:join([Priv, Bin]);
+    case code:priv_dir(erlexec) of
+    {error, _} ->
+        error_logger:warning_msg("Priv directory not available", []),
+        "";
+    Priv ->
+        % Find all ports using wildcard for resiliency
+        Bin = case filelib:wildcard("*/exec-port", Priv) of
+            [Port] -> Port;
+            _      ->
+                Arch = erlang:system_info(system_architecture),
+                Tail = filename:join([Arch, "exec-port"]),
+                os:find_executable(filename:join([Priv, Tail]))
+        end,
+        % Join the priv/port path
+        filename:join([Priv, Bin])
+    end;
 default(Option) ->
     proplists:get_value(Option, default()).
 


### PR DESCRIPTION
This is the patch I mentioned in the issue report.  It corrects the main issue in a way that allows an override of `portexe` to work even in situations where the `priv` directory is not available (within escripts and possibly others).

As an added bonus, I corrected a warning I was getting from the C++ compilation as a dependency under mix, that didn't show when using the rebar3 on erlexec directly. (This was done prior to debugging work to create the real fix, in order to be sure it was not part of the problem.)