### PR TITLE
added winsz message to call TIOCSWINSZ on pty master

### DIFF
--- a/c_src/exec.cpp
+++ b/c_src/exec.cpp
@@ -285,8 +285,8 @@ bool process_command()
         return false;
     }
 
-    enum CmdTypeT        {  MANAGE,  RUN,  STOP,  KILL,  LIST,  SHUTDOWN,  STDIN,  DEBUG  } cmd;
-    const char* cmds[] = { "manage","run","stop","kill","list","shutdown","stdin","debug" };
+    enum CmdTypeT        {  MANAGE,  RUN,  STOP,  KILL,  LIST,  SHUTDOWN,  STDIN,  DEBUG, WINSZ  } cmd;
+    const char* cmds[] = { "manage","run","stop","kill","list","shutdown","stdin","debug", "winsz" };
 
     /* Determine the command */
     if ((int)(cmd = (CmdTypeT) eis.decodeAtomIndex(cmds, command)) < 0) {
@@ -395,6 +395,26 @@ bool process_command()
             send_pid_list(transId, children);
             break;
         }
+        case WINSZ: {
+            // {winsz, OsPid::integer(), rows::integer(), cols::integer()}
+            long pid, rows, cols;
+            if (arity != 4
+                || eis.decodeInt(pid) < 0
+                || eis.decodeInt(rows) < 0
+                || eis.decodeInt(cols) < 0) {
+                send_error_str(transId, true, "badarg");
+                break;
+            }
+            MapChildrenT::iterator it = children.find(pid);
+            if (it == children.end()) {
+                if (debug)
+                    fprintf(stderr, "pid %ld doesn't exist\r\n", pid);
+                break;
+            }
+            set_pid_winsz(it->second, rows, cols);
+            break;
+        }
+            
         case STDIN: {
             // {stdin, OsPid::integer(), Data::binary()}
             long pid;

--- a/c_src/exec.hpp
+++ b/c_src/exec.hpp
@@ -151,6 +151,7 @@ int     read_sigchld(pid_t& child);
 void    check_child_exit(pid_t pid);
 int     set_nice(pid_t pid,int nice, std::string& error);
 bool    process_sigchld();
+bool    set_pid_winsz(CmdInfo& ci, int rows, int cols);
 bool    process_pid_input(CmdInfo& ci);
 void    process_pid_output(CmdInfo& ci, int maxsize = 4096);
 int     send_ok(int transId, long value = -1);

--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -102,6 +102,21 @@ int set_nice(pid_t pid,int nice, std::string& error)
 }
 
 //------------------------------------------------------------------------------
+bool set_pid_winsz(CmdInfo& ci, int rows, int cols)
+{
+    int& fd = ci.stream_fd[STDIN_FILENO];
+    int r;
+    struct winsize ws;
+    ws.ws_row = rows;
+    ws.ws_col = cols;
+    r = ioctl(fd, TIOCSWINSZ, &ws);
+    if (debug)
+        fprintf(stderr, "TIOCSWINSZ rows=%d cols=%d ret=%d\n", rows, cols, r);
+    
+    return true;
+}
+
+//------------------------------------------------------------------------------
 bool process_pid_input(CmdInfo& ci)
 {
     int& fd = ci.stream_fd[STDIN_FILENO];


### PR DESCRIPTION
I'm using erlexec to run remote terminals, and they need the TIOCSWINSZ ioctl to change the window size.

remote terminals also need a few other things, like setting the TERM environment variable, and that'll be coming up next.
