### PR TITLE
add DragonFlyBSD

### DIFF
--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -7,7 +7,7 @@ namespace ei {
 //------------------------------------------------------------------------------
 // DARWIN doesn't have ptsname_r()
 //------------------------------------------------------------------------------
-#if defined(__MACH__) || defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__MACH__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__)
 int ptsname_r(int fd, char* buf, size_t buflen) {
   char *name = ptsname(fd);
   if (name == NULL) {

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -61,6 +61,9 @@ maps:to_list(lists:foldl(
                      {"freebsd",   "CXXFLAGS", "$CXXFLAGS -std=c++11 -DHAVE_SETRESUID" ++ X64},
                      {"freebsd",   "LDFLAGS",  "$LDFLAGS" ++ X64},
 
+                     {"dragonfly",   "CXXFLAGS", "$CXXFLAGS -std=c++11 -DHAVE_SETRESUID" ++ X64},
+                     {"dragonfly",   "LDFLAGS",  "$LDFLAGS" ++ X64},
+
                      {"linux",   "CXXFLAGS", "$CXXFLAGS -std=c++11 -DHAVE_SETRESUID" ++ LinCXX},
                      {"linux",   "LDFLAGS",  "$LDFLAGS" ++ LinLD},
 


### PR DESCRIPTION
Possible to add support for DragonFlyBSD? Tested these changes using Zotonic, which allow erlexec to compile properly. Reference: https://github.com/zotonic/zotonic/issues/1938

DragonFlyBSD is a fork of FreeBSD so adding support should be as simple as the above, but will report back if I do notice any issues...