### PR TITLE
Now compile on OpenBSD but was not totally tested.

### DIFF
--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -7,7 +7,7 @@ namespace ei {
 //------------------------------------------------------------------------------
 // DARWIN doesn't have ptsname_r()
 //------------------------------------------------------------------------------
-#if defined(__MACH__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__)
+#if defined(__MACH__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__OpenBSD__)
 int ptsname_r(int fd, char* buf, size_t buflen) {
   char *name = ptsname(fd);
   if (name == NULL) {

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -61,6 +61,9 @@ maps:to_list(lists:foldl(
                      {"freebsd",   "CXXFLAGS", "$CXXFLAGS -std=c++11 -DHAVE_SETRESUID" ++ X64},
                      {"freebsd",   "LDFLAGS",  "$LDFLAGS" ++ X64},
 
+                     {"openbsd",   "CXXFLAGS", "$CXXFLAGS -std=c++11 -DHAVE_SETRESUID" ++ X64},
+                     {"openbsd",   "LDFLAGS",  "$LDFLAGS" ++ X64},
+
                      {"dragonfly",   "CXXFLAGS", "$CXXFLAGS -std=c++11 -DHAVE_SETRESUID" ++ X64},
                      {"dragonfly",   "LDFLAGS",  "$LDFLAGS" ++ X64},
 


### PR DESCRIPTION
It seems `erlexec` does not compile well on OpenBSD-current (67+) at this time:

```txt
$ uname -a
OpenBSD kin.puffy 6.7 GENERIC.MP#209 amd64

$ rebar3 compile
c_src/exec.cpp:496:6: error: #error setresuid(3) not supported!
```

I added the openbsd support. unfortunately, rebar3 pc plugin does not support OpenBSD as well, so you need to set CXX variable to c++ (clang/llvm default compiler
on OpenBSD):

```sh
CXX=c++ rebar3 compile
```

or

```sh
CXX=c++ gmake
```