### PR TITLE
Fix a few clang(-tidy) issues

### DIFF
--- a/c_src/ei++.cpp
+++ b/c_src/ei++.cpp
@@ -348,7 +348,7 @@ int Serializer::ei_x_encode_double(ei_x_buff* x, double dbl)
     int i = x->index;
     ei_encode_double(NULL, &i, dbl);
     if (!x_fix_buff(x, i))
-    return -1;
+        return -1;
     return ei_encode_double(x->buff, &x->index, dbl);
 }
 

--- a/c_src/ei++.hpp
+++ b/c_src/ei++.hpp
@@ -364,11 +364,11 @@ namespace ei {
             if (m_wbuf.resize(m_wIdx + n + 16, true) == NULL)
                 throw "out of memory";
         }
-        static int ei_decode_double(const char *buf, int *m_wIdx, double *p);
-        static int ei_encode_double(char *buf, int *m_wIdx, double p);
+        static int ei_decode_double(const char *buf, int *index, double *p);
+        static int ei_encode_double(char *buf, int *index, double p);
         static int ei_x_encode_double(ei_x_buff* x, double d);
-        static int read_exact (int fd, char *buf, size_t len, size_t& offset);
-        static int write_exact(int fd, const char *buf, size_t len, size_t& offset);
+        static int read_exact (int fd, char *buf, size_t len, size_t& got);
+        static int write_exact(int fd, const char *buf, size_t len, size_t& wrote);
     public:
 
         Serializer(int _headerSz = 2)
@@ -592,10 +592,10 @@ namespace ei {
     };
 
     /// Dump content of internal buffer to stream.
-    std::ostream& dump(std::ostream& out, const unsigned char* a_buf = NULL, int n = 0, bool eol = true);
+    std::ostream& dump(std::ostream& os, const unsigned char* buf = NULL, int n = 0, bool eol = true);
     // Write ei_x_buff to stream
     std::ostream& operator<< (std::ostream& os, const ei_x_buff& buf);
-    bool dump(const char* header, std::ostream& out, const ei_x_buff& buf, bool condition);
+    bool dump(const char* header, std::ostream& os, const ei_x_buff& buf, bool condition);
 
 } // namespace
 

--- a/c_src/exec.cpp
+++ b/c_src/exec.cpp
@@ -140,8 +140,7 @@ int main(int argc, char* argv[])
 
     // Process command arguments and do initialization
     if (argc > 1) {
-        int res;
-        for(res = 1; res < argc; res++) {
+        for(int res = 1; res < argc; res++) {
             if (strcmp(argv[res], "-h") == 0 || strcmp(argv[res], "--help") == 0) {
                 usage(argv[0]);
             } else if (strcmp(argv[res], "-debug") == 0) {

--- a/c_src/exec.cpp
+++ b/c_src/exec.cpp
@@ -326,7 +326,7 @@ bool process_command()
             pid_t      realpid;
             int        ret;
 
-            if (arity != 3 || (eis.decodeInt(pid)) < 0 || po.ei_decode(eis) < 0 || pid <= 0) {
+            if (arity != 3 || (eis.decodeInt(pid)) < 0 || po.ei_decode() < 0 || pid <= 0) {
                 send_error_str(transId, true, "badarg");
                 return true;
             }
@@ -354,7 +354,7 @@ bool process_command()
             // {run, Cmd::string(), Options::list()}
             CmdOptions po(run_as_euid);
 
-            if (arity != 3 || po.ei_decode(eis, true) < 0) {
+            if (arity != 3 || po.ei_decode(true) < 0) {
                 send_error_str(transId, false, po.error().c_str());
                 break;
             } else if (po.cmd().empty() || po.cmd().front().empty()) {

--- a/c_src/exec.cpp
+++ b/c_src/exec.cpp
@@ -462,7 +462,7 @@ bool process_command()
                 break;
             }
 
-            if (!data.size()) {
+            if (data.empty()) {
                 if (debug)
                     fprintf(stderr, "Warning: ignoring empty input on stdin of pid %ld.\r\n", pid);
                 break;
@@ -612,9 +612,9 @@ int finalize(fd_set& readfds)
     TimeVal now(TimeVal::NOW);
     TimeVal deadline(now, FINALIZE_DEADLINE_SEC, 0);
 
-    while (children.size() > 0) {
+    while (!children.empty()) {
         now.now();
-        if (children.size() > 0 || !exited_children.empty()) {
+        if (!children.empty() || !exited_children.empty()) {
             bool term = false;
             check_children(now, term, pipe_valid);
         }
@@ -627,7 +627,7 @@ int finalize(fd_set& readfds)
             transient_pids.erase(it);
         }
 
-        if (children.size() == 0)
+        if (children.empty())
             break;
 
         while (true) {

--- a/c_src/exec.cpp
+++ b/c_src/exec.cpp
@@ -90,7 +90,7 @@ pid_t           ei::self_pid;
 bool    process_command();
 void    initialize(int userid, bool use_alt_fds, bool is_root,
                    bool requested_root);
-int     finalize(fd_set& read_fds);
+int     finalize(fd_set& readfds);
 
 //-------------------------------------------------------------------------
 // Local Functions

--- a/c_src/exec.cpp
+++ b/c_src/exec.cpp
@@ -278,13 +278,13 @@ int main(int argc, char* argv[])
 
 bool process_command()
 {
-    int  err, arity;
+    int  arity;
     long transId;
     std::string command;
 
     // Note that if we were using non-blocking reads, we'd also need to check
     // for errno EWOULDBLOCK.
-    if ((err = eis.read()) < 0) {
+    if (eis.read() < 0) {
         if (debug)
             fprintf(stderr, "Broken Erlang command pipe (%d): %s [line:%d]\r\n",
                 errno, strerror(errno), __LINE__);

--- a/c_src/exec.hpp
+++ b/c_src/exec.hpp
@@ -285,7 +285,6 @@ public:
         m_cenv = NULL;
     }
 
-    const char*         cstr_error()    const { return m_err.str().c_str(); }
     std::string         error()         const { return m_err.str();  }
     const std::string&  executable()    const { return m_executable; }
     const CmdArgsList&  cmd()           const { return m_cmd; }

--- a/c_src/exec.hpp
+++ b/c_src/exec.hpp
@@ -328,7 +328,7 @@ public:
         m_std_stream[i].clear();
     }
 
-    int ei_decode(ei::Serializer& ei, bool getCmd = false);
+    int ei_decode(bool getCmd = false);
     int init_cenv();
 };
 

--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -702,7 +702,6 @@ void close_stdin(CmdInfo& ci)
     close(fd);
     fd = REDIRECT_CLOSE;
     ci.stdin_queue.clear();
-    return;
 }
 
 //------------------------------------------------------------------------------

--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -483,7 +483,7 @@ pid_t start_child(CmdOptions& op, std::string& error)
         }
 
         const char* executable = op.executable().empty()
-            ? (const char*)argv[0] : op.executable().c_str();
+            ? argv[0] : op.executable().c_str();
 
         // Execute the process
         if (execve(executable, (char* const*)argv, op.env()) < 0) {

--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -1002,7 +1002,7 @@ int set_nonblock_flag(pid_t pid, int fd, bool value)
 }
 
 //------------------------------------------------------------------------------
-int CmdOptions::ei_decode(ei::Serializer& ei, bool getCmd)
+int CmdOptions::ei_decode(bool getCmd)
 {
     // {Cmd::string()|binary()|[string()|binary()], [Option]}
     //      Option = {env, Strings::[string()]} | {cd, Dir::string()|binary()}

--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -325,7 +325,7 @@ pid_t start_child(CmdOptions& op, std::string& error)
         );
         if (!op.executable().empty())
             fprintf(stderr, "  Executable: %s\r\n", op.executable().c_str());
-        if (op.cmd().size() > 0) {
+        if (!op.cmd().empty()) {
             int i = 0;
             if (op.shell()) {
                 const char* s = getenv("SHELL");
@@ -1196,7 +1196,7 @@ int CmdOptions::ei_decode(bool getCmd)
                     } else if (type == etTuple && sz == 2) {
                         eis.decodeTupleSize();
                         std::string val;
-                        if (!eis.decodeStringOrBinary(key) && key.size() > 0) {
+                        if (!eis.decodeStringOrBinary(key) && !key.empty()) {
                             bool bval;
                             if (!eis.decodeStringOrBinary(val)) {
                                 res = true;


### PR DESCRIPTION
I compiled the code with clang++-11 and let clang-tidy-11 run like. It reports a few issues, mostly just style issues or c++11 (and newer) suggested changes. A few of of those reports (that do not require c++11) are fixed here.

Some git commit messages contain the message from clang-tidy.

It is nothing critical.
