### PR TITLE
Create CmdInfo objects directly in the map and fix one error from clang 11

### DIFF
--- a/c_src/exec.cpp
+++ b/c_src/exec.cpp
@@ -353,10 +353,8 @@ bool process_command(bool is_err)
                 return true;
             }
 
-            CmdInfo ci(true, po.kill_cmd(), realpid, po.success_exit_code(), po.kill_group(),
-                       po.dbg());
-            ci.kill_timeout = po.kill_timeout();
-            children[realpid] = ci;
+            children.emplace(realpid, CmdInfo(true, po.kill_cmd(), realpid, po.success_exit_code(),
+                                              po.kill_group(), po.dbg(), po.kill_timeout()));
 
             // Set nice priority for managed process if option is present
             std::string error;
@@ -382,16 +380,15 @@ bool process_command(bool is_err)
             if ((pid = start_child(po, err)) < 0)
                 send_error_str(transId, false, "Couldn't start pid: %s", err.c_str());
             else {
-                CmdInfo ci(po.cmd(), po.kill_cmd(), pid,
-                           getpgid(pid),
-                           po.success_exit_code(), false,
-                           po.stream_fd(STDIN_FILENO),
-                           po.stream_fd(STDOUT_FILENO),
-                           po.stream_fd(STDERR_FILENO),
-                           po.kill_timeout(),
-                           po.kill_group(),
-                           po.dbg());
-                children[pid] = ci;
+                children.emplace(pid, CmdInfo(po.cmd(), po.kill_cmd(), pid,
+                                              getpgid(pid),
+                                              po.success_exit_code(), false,
+                                              po.stream_fd(STDIN_FILENO),
+                                              po.stream_fd(STDOUT_FILENO),
+                                              po.stream_fd(STDERR_FILENO),
+                                              po.kill_timeout(),
+                                              po.kill_group(),
+                                              po.dbg()));
                 send_pid(transId, pid);
             }
             break;

--- a/c_src/exec.cpp
+++ b/c_src/exec.cpp
@@ -75,7 +75,8 @@ bool  ei::pipe_valid      = true;
 int   ei::max_fds;
 int   ei::dev_null;
 int   ei::sigchld_pipe[2] = { -1, -1 }; // Pipe for delivering sig child details
-int   run_as_euid         = INT_MAX;
+
+static int run_as_euid    = INT_MAX;
 
 //-------------------------------------------------------------------------
 // Types & variables
@@ -99,7 +100,7 @@ int     finalize();
 // Local Functions
 //-------------------------------------------------------------------------
 
-void usage(char* progname) {
+static void usage(char* progname) {
     fprintf(stderr,
         "Usage:\n"
         "   %s [-n] [-root] [-alarm N] [-debug [Level]] [-user User]\n"

--- a/c_src/exec.hpp
+++ b/c_src/exec.hpp
@@ -405,7 +405,7 @@ inline int write_sigchld(pid_t child)
     return 0;
 }
 
-inline void gotsigchild(int signal, siginfo_t* si, void* context)
+inline void gotsigchild(int signal, siginfo_t* si, void* /*context*/)
 {
     // If someone used kill() to send SIGCHLD ignore the event
     if (si->si_code == SI_USER || signal != SIGCHLD)

--- a/c_src/exec.hpp
+++ b/c_src/exec.hpp
@@ -298,64 +298,53 @@ public:
 /// structure will contain its run-time information.
 //-------------------------------------------------------------------------
 struct CmdInfo {
-    CmdArgsList     cmd;            // Executed command
-    pid_t           cmd_pid;        // Pid of the custom kill command
-    pid_t           cmd_gid;        // Command's group ID
-    std::string     kill_cmd;       // Kill command to use (default: use SIGTERM)
-    kill_cmd_pid_t  kill_cmd_pid;   // Pid of the command that <pid> is supposed to kill
-    ei::TimeVal     deadline;       // Time when the <cmd_pid> is supposed to be killed using SIGTERM.
-    bool            sigterm;        // <true> if sigterm was issued.
-    bool            sigkill;        // <true> if sigkill was issued.
-    int             kill_timeout;   // Pid shutdown interval in sec before it's killed with SIGKILL
-    bool            kill_group;     // Indicates if at exit the whole group needs to be killed
-    int             success_code;   // Exit code to use on success
-    bool            managed;        // <true> if this pid is started externally, but managed by erlexec
-    int             stream_fd[3];   // Pipe fd getting   process's stdin/stdout/stderr
-    int             stdin_wr_pos;   // Offset of the unwritten portion of the head item of stdin_queue
-    int             dbg = 0;        // Debug flag
+    CmdArgsList     cmd;               // Executed command
+    pid_t           cmd_pid;           // Pid of the custom kill command
+    pid_t           cmd_gid;           // Command's group ID
+    std::string     kill_cmd;          // Kill command to use (default: use SIGTERM)
+    kill_cmd_pid_t  kill_cmd_pid = -1; // Pid of the command that <pid> is supposed to kill
+    ei::TimeVal     deadline;          // Time when the <cmd_pid> is supposed to be killed using SIGTERM.
+    bool            sigterm = false;   // <true> if sigterm was issued.
+    bool            sigkill = false;   // <true> if sigkill was issued.
+    int             kill_timeout;      // Pid shutdown interval in sec before it's killed with SIGKILL
+    bool            kill_group;        // Indicates if at exit the whole group needs to be killed
+    int             success_code;      // Exit code to use on success
+    bool            managed;           // <true> if this pid is started externally, but managed by erlexec
+    int             stream_fd[3];      // Pipe fd getting   process's stdin/stdout/stderr
+    int             stdin_wr_pos = 0;  // Offset of the unwritten portion of the head item of stdin_queue
+    int             dbg = 0;           // Debug flag
 #if defined(USE_POLL) && USE_POLL > 0
-    int             poll_fd_idx[3]; // Indexes to the pollfd structure in the poll array
+    int             poll_fd_idx[3] = {-1,-1,-1}; // Indexes to the pollfd structure in the poll array
 #endif
     std::list<std::string> stdin_queue;
 
-    CmdInfo() {
-        new (this) CmdInfo(CmdArgsList(), "", 0, INT_MAX, 0);
-    }
-    CmdInfo(const CmdInfo& ci) {
-        new (this) CmdInfo(ci.cmd, ci.kill_cmd.c_str(), ci.cmd_pid, ci.cmd_gid,
-                           ci.success_code, ci.managed,
-                           ci.stream_fd[STDIN_FILENO], ci.stream_fd[STDOUT_FILENO],
-                           ci.stream_fd[STDERR_FILENO], ci.kill_timeout, ci.kill_group);
-    }
-    CmdInfo(bool managed, const char* _kill_cmd, pid_t _cmd_pid, int _ok_code,
-            bool _kill_group = false, int _debug = 0) {
-        new (this) CmdInfo(cmd, _kill_cmd, _cmd_pid, getpgid(_cmd_pid), _ok_code, managed,
-                           REDIRECT_NULL, REDIRECT_NONE, REDIRECT_NONE, KILL_TIMEOUT_SEC,
-                           _kill_group, _debug);
-    }
+    // delete default constructor, copy-ctor and assignment operator
+    CmdInfo() = delete;
+    CmdInfo(const CmdInfo&) = delete;
+    CmdInfo& operator=(const CmdInfo&) = delete;
+
+    // enable default move constructor to be able to put it into a map via emplace
+    CmdInfo(CmdInfo&& ci) = default;
+
+    CmdInfo(bool _managed, const char* _kill_cmd, pid_t _cmd_pid, int _ok_code,
+            bool _kill_group, int _debug, int _kill_timeout)
+        : CmdInfo(cmd, _kill_cmd, _cmd_pid, getpgid(_cmd_pid), _ok_code, _managed,
+                  REDIRECT_NULL, REDIRECT_NONE, REDIRECT_NONE, _kill_timeout,
+                  _kill_group, _debug)
+    {}
+  
     CmdInfo(const CmdArgsList& _cmd, const char* _kill_cmd, pid_t _cmd_pid, pid_t _cmd_gid,
-            int  _success_code,
-            bool _managed      = false,
-            int  _stdin_fd     = REDIRECT_NULL,
-            int  _stdout_fd    = REDIRECT_NONE,
-            int  _stderr_fd    = REDIRECT_NONE,
-            int  _kill_timeout = KILL_TIMEOUT_SEC,
-            bool _kill_group   = false,
-            int  _debug        = 0)
+            int _success_code, bool _managed, int _stdin_fd, int _stdout_fd, int _stderr_fd,
+            int _kill_timeout, bool _kill_group, int _debug)
         : cmd(_cmd)
         , cmd_pid(_cmd_pid)
         , cmd_gid(_cmd_gid)
-        , kill_cmd(_kill_cmd), kill_cmd_pid(-1)
-        , sigterm(false), sigkill(false)
+        , kill_cmd(_kill_cmd)
         , kill_timeout(_kill_timeout)
         , kill_group(_kill_group)
         , success_code(_success_code)
         , managed(_managed)
-        , stdin_wr_pos(0)
         , dbg(_debug)
-        #if defined(USE_POLL) && USE_POLL > 0
-        , poll_fd_idx{-1,-1,-1}
-        #endif
     {
         stream_fd[STDIN_FILENO]  = _stdin_fd;
         stream_fd[STDOUT_FILENO] = _stdout_fd;

--- a/c_src/exec.hpp
+++ b/c_src/exec.hpp
@@ -181,22 +181,22 @@ struct CmdOptions {
 private:
     ei::StringBuffer<256>   m_tmp;
     std::stringstream       m_err;
-    bool                    m_shell;
-    bool                    m_pty;
+    bool                    m_shell = true;
+    bool                    m_pty = false;
     std::string             m_executable;
     CmdArgsList             m_cmd;
     std::string             m_cd;
     std::string             m_kill_cmd;
-    int                     m_kill_timeout;
-    bool                    m_kill_group;
+    int                     m_kill_timeout = KILL_TIMEOUT_SEC;
+    bool                    m_kill_group = false;
     bool                    m_is_kill_cmd; // true if this represents a custom kill command
     MapEnv                  m_env;
-    const char**            m_cenv;
-    bool                    m_env_clear;
+    const char**            m_cenv = NULL;
+    bool                    m_env_clear = false;
     long                    m_nice;     // niceness level
     int                     m_group;    // used in setgid()
     int                     m_user;     // run as
-    int                     m_success_exit_code;
+    int                     m_success_exit_code = 0;
     std::string             m_std_stream[3];
     bool                    m_std_stream_append[3];
     int                     m_std_stream_fd[3];
@@ -213,31 +213,29 @@ private:
     }
 
 public:
-    CmdOptions(int def_user=INT_MAX)
-        : m_tmp(0, 256), m_shell(true), m_pty(false)
-        , m_kill_timeout(KILL_TIMEOUT_SEC)
-        , m_kill_group(false)
+    explicit CmdOptions(int def_user=INT_MAX)
+        : m_tmp(0, 256)
         , m_is_kill_cmd(false)
-        , m_cenv(NULL), m_env_clear(false)
         , m_nice(INT_MAX)
         , m_group(INT_MAX), m_user(def_user)
-        , m_success_exit_code(0)
     {
         init_streams();
     }
-    CmdOptions(const CmdArgsList& cmd, const char* cd = NULL, const MapEnv& env = MapEnv(),
-               int  user = INT_MAX, int nice = INT_MAX, int group = INT_MAX,
-               bool is_kill_cmd=false)
-        : m_shell(true), m_pty(false), m_cmd(cmd), m_cd(cd ? cd : "")
-        , m_kill_timeout(KILL_TIMEOUT_SEC)
-        , m_kill_group(false)
+    CmdOptions(const CmdArgsList& cmd, const char* cd, const MapEnv& env,
+               int user, int nice, int group, bool is_kill_cmd)
+        : m_cmd(cmd), m_cd(cd ? cd : "")
         , m_is_kill_cmd(is_kill_cmd)
         , m_env(env)
-        , m_cenv(NULL),   m_nice(INT_MAX)
+        , m_nice(nice)
         , m_group(group), m_user(user)
     {
         init_streams();
     }
+
+    // prevent copying
+    CmdOptions(const CmdOptions&) = delete;
+    CmdOptions& operator=(const CmdOptions&) = delete;
+
     ~CmdOptions() {
         if (m_cenv != (const char**)environ) delete [] m_cenv;
         m_cenv = NULL;

--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -315,7 +315,7 @@ pid_t start_child(CmdOptions& op, std::string& error)
     ei::StringBuffer<128> err;
 
     // Optionally setup pseudoterminal
-    int fdm;
+    int fdm = 0;
 
     if (op.pty()) {
         if (getpty(fdm, err) < 0) {

--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -937,15 +937,15 @@ void check_child_exit(pid_t pid)
 }
 
 //------------------------------------------------------------------------------
-int send_pid_list(int transId, const MapChildrenT& children)
+int send_pid_list(int transId, const MapChildrenT& _children)
 {
     // Reply: {TransId, [OsPid::integer()]}
     eis.reset();
     eis.encodeTupleSize(2);
     eis.encode(transId);
-    eis.encodeListSize(children.size());
-    for(auto it=children.begin(), end=children.end(); it != end; ++it)
-        eis.encode(it->first);
+    eis.encodeListSize(_children.size());
+    for(const auto& it: _children)
+        eis.encode(it.first);
     eis.encodeListEnd();
     return eis.write();
 }

--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -269,7 +269,7 @@ void process_pid_output(CmdInfo& ci, int stream_id, int maxsize)
 }
 
 //------------------------------------------------------------------------------
-int getpty(int& fdmp, ei::StringBuffer<128>& err) {
+static int getpty(int& fdmp, ei::StringBuffer<128>& err) {
     int fdm;
     int rc;
 
@@ -741,7 +741,7 @@ void stop_child(pid_t pid, int transId, const TimeVal& now)
 }
 
 //------------------------------------------------------------------------------
-int send_std_error(int err, bool notify, int transId)
+static int send_std_error(int err, bool notify, int transId)
 {
     if (err == 0) {
         if (notify) send_ok(transId);

--- a/c_src/poll_handler.hpp
+++ b/c_src/poll_handler.hpp
@@ -11,7 +11,7 @@ Date:   2020-01-06
 #include "ei++.hpp"
 
 struct PollHandler {
-    PollHandler() : command_index{-1}, sigchild_index{-1} {};
+    PollHandler() : command_index{-1}, sigchild_index{-1} {}
   
     void append_read_fd(int fd, FdType type = FdType::CHILD_PROC, bool error = false) {
         fds.push_back(pollfd{fd, (short) (error ? (POLLIN | POLLERR) : POLLIN), 0});

--- a/c_src/select_handler.hpp
+++ b/c_src/select_handler.hpp
@@ -14,7 +14,7 @@ struct SelectHandler {
         FD_ZERO(&errfds);
     }
     
-    void clear() { new (this)(); }
+    void clear() { new (this) SelectHandler(); }
     
     void append_read_fd(int fd, FdType type = FdType::CHILD_PROC, bool _error = false) {
         FD_SET(fd, &readfds);

--- a/c_src/select_handler.hpp
+++ b/c_src/select_handler.hpp
@@ -12,7 +12,7 @@ struct SelectHandler {
         FD_ZERO(&writefds);
         FD_ZERO(&readfds);
         FD_ZERO(&errfds);
-    };
+    }
     
     void clear() { new (this)(); }
     


### PR DESCRIPTION
Next round... (probably the last one for now)

I had a look at compiler warnings etc from clang 11 and fixed a few.
My initial intention was to remove `new(this)Class();` because of https://isocpp.org/wiki/faq/ctors#init-methods and use c++11 delegating constructor. But since CmdInfo is only used in a map, i instead use only the move constructor and removed the copy constructor (and also the default operator=()).

Summary:
- Create CmdInfo objects directly in the map using move constructor
- delete unused CmdInfo constructors
- fixed a few compiler warnings
- fixed one compiler error from clang 11, see https://github.com/saleyn/erlexec/commit/4f5e9b05f2150d515c16ba0312d51f28ab12adb3