### PR TITLE
Allow setting arbitrary pty options

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,41 @@ Got: {stdout,26143,<<"baz\nbar\nfoo\n">>}
 % Execute a command with a pty
 38> exec:run("echo hello", [sync, stdout, pty]).
 {ok,[{stdout,[<<"hello">>,<<"\r\n">>]}]}
-```
+
+% Execute a command with pty echo
+39> {ok, P0, I0} = exec:run("cat", [stdin, stdout, {stderr, stdout}, pty, pty_echo]).
+{ok,<0.162.0>,17086}
+40> exec:send(I0, <<"hello">>).
+ok
+41> flush().
+Shell got {stdout,17086,<<"hello">>}
+ok
+42> exec:send(I0, <<"\n">>).
+ok
+43> flush().
+Shell got {stdout,17086,<<"\r\n">>}
+Shell got {stdout,17086,<<"hello\r\n">>}
+ok
+44> exec:send(I, <<3>>).
+ok
+45> flush().
+Shell got {stdout,17086,<<"^C">>}
+Shell got {'DOWN',17086,process,<0.162.0>,{exit_status,2}}
+ok
+
+% Execute a command with custom pty options
+46> {ok, P1, I1} = exec:run("cat", [stdin, stdout, {stderr, stdout}, {pty, [{vintr, 2}]}, monitor]).
+{ok,<0.199.0>,16662}
+47> exec:send(I1, <<3>>).
+ok
+48> flush().
+ok
+49> exec:send(I1, <<2>>).
+ok
+50> flush().
+Shell got {'DOWN',16662,process,<0.199.0>,{exit_status,2}}
+ok
+'''
  
 ### Kill a process group at process exit
 ```erlang
@@ -516,13 +550,13 @@ Got: {stdout,26143,<<"baz\nbar\nfoo\n">>}
 % equal to the OS pid of that process (value = GID). The next two commands
 % are assigned to the same process group GID. As soon as the P0 process exits
 % P1 and P2 will also get terminated by signal 15 (SIGTERM):
-39> {ok, P0, GID} = exec:run("sleep 10",  [{group, 0},   kill_group]).
+51> {ok, P2, GID} = exec:run("sleep 10",  [{group, 0},   kill_group]).
 {ok,<0.37.0>,25306}
-40> {ok, P1,   _} = exec:run("sleep 15",  [{group, GID}, monitor]).
+52> {ok, P3,   _} = exec:run("sleep 15",  [{group, GID}, monitor]).
 {ok,<0.39.0>,25307}
-41> {ok, P2,   _} = exec:run("sleep 15",  [{group, GID}, monitor]).
+53> {ok, P4,   _} = exec:run("sleep 15",  [{group, GID}, monitor]).
 {ok,<0.41.0>,25308}
-42> flush().
+54> flush().
 Shell got {'DOWN',25307,process,<0.39.0>,{exit_status,15}}
 Shell got {'DOWN',25308,process,<0.41.0>,{exit_status,15}}
 ok

--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ ok
 50> flush().
 Shell got {'DOWN',16662,process,<0.199.0>,{exit_status,2}}
 ok
-'''
+```
  
 ### Kill a process group at process exit
 ```erlang

--- a/c_src/exec.cpp
+++ b/c_src/exec.cpp
@@ -39,8 +39,9 @@
               stdin  | {stdin, null | close | File::string()} |
               stdout | {stdout, Device::string()} |
               stderr | {stderr, Device::string()} |
-              pty    | {success_exit_code, N::integer()} |
-              pty_echo
+              pty    | {pty, [{echo, 1}, ...]}    |
+              pty_echo |
+              {success_exit_code, N::integer()}
 
     Device  = close | null | stderr | stdout | File::string() | {append, File::string()}
 
@@ -334,7 +335,7 @@ bool process_command(bool is_err)
     }
 
     enum CmdTypeT        {  MANAGE,  RUN,  STOP,  KILL,  LIST,  SHUTDOWN,  STDIN,  DEBUG, WINSZ  } cmd;
-    const char* cmds[] = { "manage","run","stop","kill","list","shutdown","stdin","debug", "winsz" };
+    const char* cmds[] = { "manage","run","stop","kill","list","shutdown","stdin","debug","winsz" };
 
     /* Determine the command */
     if ((int)(cmd = (CmdTypeT) eis.decodeAtomIndex(cmds, command)) < 0) {

--- a/c_src/exec.cpp
+++ b/c_src/exec.cpp
@@ -334,7 +334,7 @@ bool process_command(bool is_err)
         return false;
     }
 
-    enum CmdTypeT        {  MANAGE,  RUN,  STOP,  KILL,  LIST,  SHUTDOWN,  STDIN,  DEBUG, WINSZ, PTYOPTS  } cmd;
+    enum CmdTypeT        {  MANAGE,  RUN,  STOP,  KILL,  LIST,  SHUTDOWN,  STDIN,  DEBUG,  WINSZ,  PTY_OPTS  } cmd;
     const char* cmds[] = { "manage","run","stop","kill","list","shutdown","stdin","debug","winsz","pty_opts" };
 
     /* Determine the command */
@@ -467,7 +467,7 @@ bool process_command(bool is_err)
                 send_error_str(transId, false, "failed to set window size");
             break;
         }
-        case PTYOPTS: {
+        case PTY_OPTS: {
             // {pty_opts, OsPid::integer(), pty_opts::list()}
             long pid;
             if (arity != 3 || eis.decodeInt(pid) < 0) {

--- a/c_src/exec.hpp
+++ b/c_src/exec.hpp
@@ -151,6 +151,7 @@ typedef std::pair<pid_t, ei::TimeVal>           KillPidInfoT;
 typedef std::map <kill_cmd_pid_t, KillPidInfoT> MapKillPidT;
 typedef std::map<std::string, std::string>      MapEnv;
 typedef MapEnv::iterator                        MapEnvIterator;
+typedef std::map<std::string, int>              MapPtyOpt;
 typedef std::map<pid_t, exit_status_t>          ExitedChildrenT;
 
 static const char* CS_DEV_NULL  = "/dev/null";
@@ -184,6 +185,7 @@ private:
     bool                    m_shell = true;
     bool                    m_pty = false;
     bool                    m_pty_echo = false;
+    MapPtyOpt               m_pty_opts;
     std::string             m_executable;
     CmdArgsList             m_cmd;
     std::string             m_cd;
@@ -248,6 +250,7 @@ public:
     bool                shell()         const { return m_shell; }
     bool                pty()           const { return m_pty; }
     bool                pty_echo()      const { return m_pty_echo; }
+    MapPtyOpt const&    pty_opts()      const { return m_pty_opts; }
     const char*   cd()                  const { return m_cd.c_str(); }
     MapEnv const& mapenv()              const { return m_env; }
     char* const*  env()                 const { return (char* const*)m_cenv; }

--- a/c_src/exec.hpp
+++ b/c_src/exec.hpp
@@ -372,6 +372,7 @@ int     set_euid(int userid);
 int     set_nice(pid_t pid,int nice, std::string& error);
 bool    process_sigchld();
 bool    set_pid_winsz(CmdInfo& ci, int rows, int cols);
+bool    set_pty_opt(struct termios *tio, std::string atom, int value);
 bool    set_cloexec_flag(int fd, bool value);
 bool    process_pid_input(CmdInfo& ci);
 void    process_pid_output(CmdInfo& ci, int stream_id, int maxsize = 4096);

--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -184,7 +184,7 @@ bool set_pid_winsz(CmdInfo& ci, int rows, int cols)
     r = ioctl(fd, TIOCSWINSZ, &ws);
     DEBUG(debug, "TIOCSWINSZ rows=%d cols=%d ret=%d\n", rows, cols, r);
     
-    return true;
+    return r == 0;
 }
 
 //------------------------------------------------------------------------------

--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -188,6 +188,41 @@ bool set_pid_winsz(CmdInfo& ci, int rows, int cols)
 }
 
 //------------------------------------------------------------------------------
+bool set_pty_opt(struct termios *tio, std::string atom, int value) {
+#define TTYCHAR(NAME, VALUE)                                                   \
+    if (atom.compare(VALUE) == 0) {                                            \
+        DEBUG(debug, "set tty_char %s\r\n", #NAME);                            \
+        tio->c_cc[NAME] = value;                                               \
+        return true;                                                           \
+    }
+
+#define TTYMODE(NAME, FIELD, VALUE)                                            \
+    if (atom.compare(VALUE) == 0) {                                            \
+        if (value) {                                                           \
+            DEBUG(debug, "enable %s = %d\r\n", #NAME, value);                  \
+            tio->FIELD |= NAME;                                                \
+        } else {                                                               \
+            DEBUG(debug, "disable %s = %d\r\n", #NAME, value);                 \
+            tio->FIELD &= ~NAME;                                               \
+        }                                                                      \
+        return true;                                                           \
+    }
+
+#define TTYSPEED(NAME, FIELD, VALUE)                                           \
+    if (atom.compare(VALUE) == 0) {                                            \
+        tio->FIELD = value;                                                    \
+        return true;                                                           \
+    }
+
+#include "ttymodes.h"
+
+#undef TTYCHAR
+#undef TTYMODE
+#undef TTYSPEED
+    return false;
+}
+
+//------------------------------------------------------------------------------
 bool process_pid_input(CmdInfo& ci)
 {
     int& fd = ci.stream_fd[STDIN_FILENO];
@@ -497,6 +532,14 @@ pid_t start_child(CmdOptions& op, std::string& error)
                 ios.c_lflag &= ~(ECHO | ECHONL | ECHOE | ECHOK);
                 // We don't check if it succeeded because if the STDIN is not a terminal
                 // it won't be able to disable the ECHO anyway.
+                tcsetattr(STDIN_FILENO, TCSANOW, &ios);
+            }
+            if (!op.pty_opts().empty()) {
+                MapPtyOpt pty_opts = op.pty_opts();
+                struct termios ios;
+                tcgetattr(STDIN_FILENO, &ios);
+                for (auto it = pty_opts.begin(), end = pty_opts.end(); it != end; ++it)
+                    set_pty_opt(&ios, it->first, it->second);
                 tcsetattr(STDIN_FILENO, TCSANOW, &ios);
             }
 
@@ -1353,9 +1396,39 @@ int CmdOptions::ei_decode(bool getcmd)
                 break;
             }
 
-            case PTY:
+            case PTY: {
                 m_pty = true;
+                // pty | {pty, [{echo, 1}, ...]}
+                // see https://www.erlang.org/doc/man/ssh_connection.html#type-term_mode
+                int opt_env_sz = eis.decodeListSize();
+                if (opt_env_sz < 0) {
+                    // this is ok, we've got just the atom pty
+                    break;
+                }
+                for (int i=0; i < opt_env_sz; i++) {
+                    int sz, type = eis.decodeType(sz);
+                    bool res = false;
+                    std::string key;
+                    int val;
+
+                    if (type == etTuple && sz == 2) {
+                        eis.decodeTupleSize();
+                        if (!eis.decodeAtom(key) && !key.empty()) {
+                            if (!eis.decodeInt(val)) {
+                                res = true;
+                            }
+                        }
+                    }
+
+                    if (!res) {
+                        m_err << op << " - invalid pty argument #" << i;
+                        return -1;
+                    }
+                    m_pty_opts[key] = val;
+                }
+                eis.decodeListEnd();
                 break;
+            }
 
             case PTY_ECHO:
                 m_pty_echo = true;

--- a/c_src/ttymodes.h
+++ b/c_src/ttymodes.h
@@ -116,5 +116,18 @@ TTYMODE(PARENB, c_cflag, "parenb")
 TTYMODE(PARODD, c_cflag, "parodd")
 
 /* name, field, atom */
+#ifdef c_ispeed
 TTYSPEED(TTY_OP_ISPEED, c_ispeed, "tty_op_ispeed")
+#endif
+
+#ifdef __c_ispeed
+TTYSPEED(TTY_OP_ISPEED, __c_ispeed, "tty_op_ispeed")
+#endif
+
+#ifdef c_ospeed
 TTYSPEED(TTY_OP_OSPEED, c_ospeed, "tty_op_ospeed")
+#endif
+
+#ifdef __c_ospeed
+TTYSPEED(TTY_OP_OSPEED, __c_ospeed, "tty_op_ospeed")
+#endif

--- a/c_src/ttymodes.h
+++ b/c_src/ttymodes.h
@@ -1,0 +1,120 @@
+// idea from:
+// https://github.com/openssh/openssh-portable/blob/2dc328023f60212cd29504fc05d849133ae47355/ttymodes.h
+
+#define TTY_OP_ISPEED 128
+#define TTY_OP_OSPEED 129
+
+/* name, atom */
+TTYCHAR(VINTR, "vintr")
+TTYCHAR(VQUIT, "vquit")
+TTYCHAR(VERASE, "verase")
+#if defined(VKILL)
+TTYCHAR(VKILL, "vkill")
+#endif /* VKILL */
+TTYCHAR(VEOF, "veof")
+#if defined(VEOL)
+TTYCHAR(VEOL, "veol")
+#endif /* VEOL */
+#ifdef VEOL2
+TTYCHAR(VEOL2, "veol2")
+#endif /* VEOL2 */
+TTYCHAR(VSTART, "vstart")
+TTYCHAR(VSTOP, "vstop")
+#if defined(VSUSP)
+TTYCHAR(VSUSP, "vsusp")
+#endif /* VSUSP */
+#if defined(VDSUSP)
+TTYCHAR(VDSUSP, "vdsusp")
+#endif /* VDSUSP */
+#if defined(VREPRINT)
+TTYCHAR(VREPRINT, "vreprint")
+#endif /* VREPRINT */
+#if defined(VWERASE)
+TTYCHAR(VWERASE, "vwerase")
+#endif /* VWERASE */
+#if defined(VLNEXT)
+TTYCHAR(VLNEXT, "vlnext")
+#endif /* VLNEXT */
+#if defined(VFLUSH)
+TTYCHAR(VFLUSH, "vflush")
+#endif /* VFLUSH */
+#ifdef VSWTCH
+TTYCHAR(VSWTCH, "vswtch")
+#endif /* VSWTCH */
+#if defined(VSTATUS)
+TTYCHAR(VSTATUS, "vstatus")
+#endif /* VSTATUS */
+#ifdef VDISCARD
+TTYCHAR(VDISCARD, "vdiscard")
+#endif /* VDISCARD */
+
+/* name, field, atom */
+TTYMODE(IGNPAR, c_iflag, "ignpar")
+TTYMODE(PARMRK, c_iflag, "parmrk")
+TTYMODE(INPCK, c_iflag, "inpck")
+TTYMODE(ISTRIP, c_iflag, "istrip")
+TTYMODE(INLCR, c_iflag, "inlcr")
+TTYMODE(IGNCR, c_iflag, "igncr")
+TTYMODE(ICRNL, c_iflag, "icrnl")
+#if defined(IUCLC)
+TTYMODE(IUCLC, c_iflag, "iuclc")
+#endif
+TTYMODE(IXON, c_iflag, "ixon")
+TTYMODE(IXANY, c_iflag, "ixany")
+TTYMODE(IXOFF, c_iflag, "ixoff")
+#ifdef IMAXBEL
+TTYMODE(IMAXBEL, c_iflag, "imaxbel")
+#endif /* IMAXBEL */
+#ifdef IUTF8
+TTYMODE(IUTF8, c_iflag, "iutf8")
+#endif /* IUTF8 */
+
+TTYMODE(ISIG, c_lflag, "isig")
+TTYMODE(ICANON, c_lflag, "icanon")
+#ifdef XCASE
+TTYMODE(XCASE, c_lflag, "xcase")
+#endif
+TTYMODE(ECHO, c_lflag, "echo")
+TTYMODE(ECHOE, c_lflag, "echoe")
+TTYMODE(ECHOK, c_lflag, "echok")
+TTYMODE(ECHONL, c_lflag, "echonl")
+TTYMODE(NOFLSH, c_lflag, "noflsh")
+TTYMODE(TOSTOP, c_lflag, "tostop")
+#ifdef IEXTEN
+TTYMODE(IEXTEN, c_lflag, "iexten")
+#endif /* IEXTEN */
+#if defined(ECHOCTL)
+TTYMODE(ECHOCTL, c_lflag, "echoctl")
+#endif /* ECHOCTL */
+#ifdef ECHOKE
+TTYMODE(ECHOKE, c_lflag, "echoke")
+#endif /* ECHOKE */
+#if defined(PENDIN)
+TTYMODE(PENDIN, c_lflag, "pendin")
+#endif /* PENDIN */
+
+TTYMODE(OPOST, c_oflag, "opost")
+#if defined(OLCUC)
+TTYMODE(OLCUC, c_oflag, "olcuc")
+#endif
+#ifdef ONLCR
+TTYMODE(ONLCR, c_oflag, "onlcr")
+#endif
+#ifdef OCRNL
+TTYMODE(OCRNL, c_oflag, "ocrnl")
+#endif
+#ifdef ONOCR
+TTYMODE(ONOCR, c_oflag, "onocr")
+#endif
+#ifdef ONLRET
+TTYMODE(ONLRET, c_oflag, "onlret")
+#endif
+
+TTYMODE(CS7, c_cflag, "cs7")
+TTYMODE(CS8, c_cflag, "cs8")
+TTYMODE(PARENB, c_cflag, "parenb")
+TTYMODE(PARODD, c_cflag, "parodd")
+
+/* name, field, atom */
+TTYSPEED(TTY_OP_ISPEED, c_ispeed, "tty_op_ispeed")
+TTYSPEED(TTY_OP_OSPEED, c_ospeed, "tty_op_ospeed")

--- a/c_src/ttymodes.h
+++ b/c_src/ttymodes.h
@@ -5,115 +5,115 @@
 #define TTY_OP_OSPEED 129
 
 /* name, atom */
-TTYCHAR(VINTR, "vintr")
-TTYCHAR(VQUIT, "vquit")
-TTYCHAR(VERASE, "verase")
+TTYCHAR(VINTR,    "vintr")
+TTYCHAR(VQUIT,    "vquit")
+TTYCHAR(VERASE,   "verase")
 #if defined(VKILL)
-TTYCHAR(VKILL, "vkill")
+TTYCHAR(VKILL,    "vkill")
 #endif /* VKILL */
-TTYCHAR(VEOF, "veof")
+TTYCHAR(VEOF,     "veof")
 #if defined(VEOL)
-TTYCHAR(VEOL, "veol")
+TTYCHAR(VEOL,     "veol")
 #endif /* VEOL */
 #ifdef VEOL2
-TTYCHAR(VEOL2, "veol2")
+TTYCHAR(VEOL2,    "veol2")
 #endif /* VEOL2 */
-TTYCHAR(VSTART, "vstart")
-TTYCHAR(VSTOP, "vstop")
+TTYCHAR(VSTART,   "vstart")
+TTYCHAR(VSTOP,    "vstop")
 #if defined(VSUSP)
-TTYCHAR(VSUSP, "vsusp")
+TTYCHAR(VSUSP,    "vsusp")
 #endif /* VSUSP */
 #if defined(VDSUSP)
-TTYCHAR(VDSUSP, "vdsusp")
+TTYCHAR(VDSUSP,   "vdsusp")
 #endif /* VDSUSP */
 #if defined(VREPRINT)
 TTYCHAR(VREPRINT, "vreprint")
 #endif /* VREPRINT */
 #if defined(VWERASE)
-TTYCHAR(VWERASE, "vwerase")
+TTYCHAR(VWERASE,  "vwerase")
 #endif /* VWERASE */
 #if defined(VLNEXT)
-TTYCHAR(VLNEXT, "vlnext")
+TTYCHAR(VLNEXT,   "vlnext")
 #endif /* VLNEXT */
 #if defined(VFLUSH)
-TTYCHAR(VFLUSH, "vflush")
+TTYCHAR(VFLUSH,   "vflush")
 #endif /* VFLUSH */
 #ifdef VSWTCH
-TTYCHAR(VSWTCH, "vswtch")
+TTYCHAR(VSWTCH,   "vswtch")
 #endif /* VSWTCH */
 #if defined(VSTATUS)
-TTYCHAR(VSTATUS, "vstatus")
+TTYCHAR(VSTATUS,  "vstatus")
 #endif /* VSTATUS */
 #ifdef VDISCARD
 TTYCHAR(VDISCARD, "vdiscard")
 #endif /* VDISCARD */
 
 /* name, field, atom */
-TTYMODE(IGNPAR, c_iflag, "ignpar")
-TTYMODE(PARMRK, c_iflag, "parmrk")
-TTYMODE(INPCK, c_iflag, "inpck")
-TTYMODE(ISTRIP, c_iflag, "istrip")
-TTYMODE(INLCR, c_iflag, "inlcr")
-TTYMODE(IGNCR, c_iflag, "igncr")
-TTYMODE(ICRNL, c_iflag, "icrnl")
+TTYMODE(IGNPAR,  c_iflag, "ignpar")
+TTYMODE(PARMRK,  c_iflag, "parmrk")
+TTYMODE(INPCK,   c_iflag, "inpck")
+TTYMODE(ISTRIP,  c_iflag, "istrip")
+TTYMODE(INLCR,   c_iflag, "inlcr")
+TTYMODE(IGNCR,   c_iflag, "igncr")
+TTYMODE(ICRNL,   c_iflag, "icrnl")
 #if defined(IUCLC)
-TTYMODE(IUCLC, c_iflag, "iuclc")
+TTYMODE(IUCLC,   c_iflag, "iuclc")
 #endif
-TTYMODE(IXON, c_iflag, "ixon")
-TTYMODE(IXANY, c_iflag, "ixany")
-TTYMODE(IXOFF, c_iflag, "ixoff")
+TTYMODE(IXON,    c_iflag, "ixon")
+TTYMODE(IXANY,   c_iflag, "ixany")
+TTYMODE(IXOFF,   c_iflag, "ixoff")
 #ifdef IMAXBEL
 TTYMODE(IMAXBEL, c_iflag, "imaxbel")
 #endif /* IMAXBEL */
 #ifdef IUTF8
-TTYMODE(IUTF8, c_iflag, "iutf8")
+TTYMODE(IUTF8,   c_iflag, "iutf8")
 #endif /* IUTF8 */
 
-TTYMODE(ISIG, c_lflag, "isig")
-TTYMODE(ICANON, c_lflag, "icanon")
+TTYMODE(ISIG,    c_lflag, "isig")
+TTYMODE(ICANON,  c_lflag, "icanon")
 #ifdef XCASE
-TTYMODE(XCASE, c_lflag, "xcase")
+TTYMODE(XCASE,   c_lflag, "xcase")
 #endif
-TTYMODE(ECHO, c_lflag, "echo")
-TTYMODE(ECHOE, c_lflag, "echoe")
-TTYMODE(ECHOK, c_lflag, "echok")
-TTYMODE(ECHONL, c_lflag, "echonl")
-TTYMODE(NOFLSH, c_lflag, "noflsh")
-TTYMODE(TOSTOP, c_lflag, "tostop")
+TTYMODE(ECHO,    c_lflag, "echo")
+TTYMODE(ECHOE,   c_lflag, "echoe")
+TTYMODE(ECHOK,   c_lflag, "echok")
+TTYMODE(ECHONL,  c_lflag, "echonl")
+TTYMODE(NOFLSH,  c_lflag, "noflsh")
+TTYMODE(TOSTOP,  c_lflag, "tostop")
 #ifdef IEXTEN
-TTYMODE(IEXTEN, c_lflag, "iexten")
+TTYMODE(IEXTEN,  c_lflag, "iexten")
 #endif /* IEXTEN */
 #if defined(ECHOCTL)
 TTYMODE(ECHOCTL, c_lflag, "echoctl")
 #endif /* ECHOCTL */
 #ifdef ECHOKE
-TTYMODE(ECHOKE, c_lflag, "echoke")
+TTYMODE(ECHOKE,  c_lflag, "echoke")
 #endif /* ECHOKE */
 #if defined(PENDIN)
-TTYMODE(PENDIN, c_lflag, "pendin")
+TTYMODE(PENDIN,  c_lflag, "pendin")
 #endif /* PENDIN */
 
-TTYMODE(OPOST, c_oflag, "opost")
+TTYMODE(OPOST,   c_oflag, "opost")
 #if defined(OLCUC)
-TTYMODE(OLCUC, c_oflag, "olcuc")
+TTYMODE(OLCUC,   c_oflag, "olcuc")
 #endif
 #ifdef ONLCR
-TTYMODE(ONLCR, c_oflag, "onlcr")
+TTYMODE(ONLCR,   c_oflag, "onlcr")
 #endif
 #ifdef OCRNL
-TTYMODE(OCRNL, c_oflag, "ocrnl")
+TTYMODE(OCRNL,   c_oflag, "ocrnl")
 #endif
 #ifdef ONOCR
-TTYMODE(ONOCR, c_oflag, "onocr")
+TTYMODE(ONOCR,   c_oflag, "onocr")
 #endif
 #ifdef ONLRET
-TTYMODE(ONLRET, c_oflag, "onlret")
+TTYMODE(ONLRET,  c_oflag, "onlret")
 #endif
 
-TTYMODE(CS7, c_cflag, "cs7")
-TTYMODE(CS8, c_cflag, "cs8")
-TTYMODE(PARENB, c_cflag, "parenb")
-TTYMODE(PARODD, c_cflag, "parodd")
+TTYMODE(CS7,     c_cflag, "cs7")
+TTYMODE(CS8,     c_cflag, "cs8")
+TTYMODE(PARENB,  c_cflag, "parenb")
+TTYMODE(PARODD,  c_cflag, "parodd")
 
 /* name, field, atom */
 #ifdef c_ispeed

--- a/src/exec.erl
+++ b/src/exec.erl
@@ -202,7 +202,7 @@
     | {stdout, stderr | output_dev_opt()}
     | {stderr, stdout | output_dev_opt()}
     | {stdout | stderr, string()|binary(), [output_file_opt()]}
-    | pty | {pty, list()}
+    | pty | {pty, pty_opts()}
     | pty_echo
     | debug | {debug, integer()}.
 %% Command options:
@@ -329,6 +329,37 @@
 -type osgid() :: integer().
 %% Representation of OS group ID.
 -export_type([ospid/0, osgid/0]).
+
+-type tty_char() :: vintr | vquit | verase | vkill | veof | veol | veol2
+    | vstart | vstop | vsusp | vdsusp | vreprint | vwerase | vlnext
+    | vflush | vswtch | vstatus | vdiscard.
+-type tty_mode() :: ignpar | parmrk | inpck | istrip | inlcr | igncr | icrnl
+    | iuclc | ixon | ixany | ixoff | imaxbel | iutf8 | isig | icanon | xcase
+    | echo | echoe | echok | echonl | noflsh | tostop | iexten | echoctl
+    | echoke | pendin | opost | olcuc | onlcr | ocrnl | onocr | onlret
+    | cs7 | cs8 | parenb | parodd.
+-type tty_mode_arg() :: 0 | 1.
+-type tty_speed() :: tty_op_ispeed | tty_op_ospeed.
+-type pty_opt() :: {tty_char(), Arg::byte()}
+    | {tty_mode(), tty_mode_arg()}
+    | {tty_speed(), Speed::integer()}.
+%% Pty options, see:
+%% <ul>
+%%      <li>[https://man7.org/linux/man-pages/man3/termios.3.html]</li>
+%%      <li>[https://datatracker.ietf.org/doc/html/rfc4254#section-8]</li>
+%% </ul>
+%% <dl>
+%% <dt>{tty_char(), Arg}</dt>
+%%      <dd>A special character with value from 0 to 255</dd>
+%% <dt>{tty_mode(), tty_mode_arg()}</dt>
+%%      <dd>A tty mode with value 0 (disabled) or 1 (enabled)</dd>
+%% <dt>{tty_speed(), Speed}</dt>
+%%      <dd>Specify input or output baud rate. Probably not really
+%%          useful for pseudo terminals, but here for completeness.</dd>
+%% </dl>
+-type pty_opts() :: list(pty_opt()).
+%% List of pty options.
+-export_type([pty_opt/0, pty_opts/0]).
 
 %%-------------------------------------------------------------------------
 %% @doc Supervised start an external program manager.
@@ -547,7 +578,7 @@ winsz(OsPid, Rows, Cols)
 %%
 %% @end
 %%-------------------------------------------------------------------------
--spec pty_opts(OsPid :: ospid() | pid(), list()) -> ok | {error, Reason::any()}.
+-spec pty_opts(OsPid :: ospid() | pid(), pty_opts()) -> ok | {error, Reason::any()}.
 pty_opts(OsPid, Opts)
   when (is_integer(OsPid) orelse is_pid(OsPid)),
        is_list(Opts) ->

--- a/src/overview.edoc
+++ b/src/overview.edoc
@@ -441,6 +441,40 @@ Got: {stdout,26143,<<"baz\nbar\nfoo\n">>}
 % Execute a command with a pty
 38> exec:run("echo hello", [sync, stdout, pty]).
 {ok,[{stdout,[<<"hello">>,<<"\r\n">>]}]}
+
+% Execute a command with pty echo
+39> {ok, P0, I0} = exec:run("cat", [stdin, stdout, {stderr, stdout}, pty, pty_echo]).
+{ok,<0.162.0>,17086}
+40> exec:send(I0, <<"hello">>).
+ok
+41> flush().
+Shell got {stdout,17086,<<"hello">>}
+ok
+42> exec:send(I0, <<"\n">>).
+ok
+43> flush().
+Shell got {stdout,17086,<<"\r\n">>}
+Shell got {stdout,17086,<<"hello\r\n">>}
+ok
+44> exec:send(I, <<3>>).
+ok
+45> flush().
+Shell got {stdout,17086,<<"^C">>}
+Shell got {'DOWN',17086,process,<0.162.0>,{exit_status,2}}
+ok
+
+% Execute a command with custom pty options
+46> {ok, P1, I1} = exec:run("cat", [stdin, stdout, {stderr, stdout}, {pty, [{vintr, 2}]}, monitor]).
+{ok,<0.199.0>,16662}
+47> exec:send(I1, <<3>>).
+ok
+48> flush().
+ok
+49> exec:send(I1, <<2>>).
+ok
+50> flush().
+Shell got {'DOWN',16662,process,<0.199.0>,{exit_status,2}}
+ok
 '''
  
 === Kill a process group at process exit ===
@@ -449,13 +483,13 @@ Got: {stdout,26143,<<"baz\nbar\nfoo\n">>}
 % equal to the OS pid of that process (value = GID). The next two commands
 % are assigned to the same process group GID. As soon as the P0 process exits
 % P1 and P2 will also get terminated by signal 15 (SIGTERM):
-39> {ok, P0, GID} = exec:run("sleep 10",  [{group, 0},   kill_group]).
+51> {ok, P2, GID} = exec:run("sleep 10",  [{group, 0},   kill_group]).
 {ok,<0.37.0>,25306}
-40> {ok, P1,   _} = exec:run("sleep 15",  [{group, GID}, monitor]).
+52> {ok, P3,   _} = exec:run("sleep 15",  [{group, GID}, monitor]).
 {ok,<0.39.0>,25307}
-41> {ok, P2,   _} = exec:run("sleep 15",  [{group, GID}, monitor]).
+53> {ok, P4,   _} = exec:run("sleep 15",  [{group, GID}, monitor]).
 {ok,<0.41.0>,25308}
-42> flush().
+54> flush().
 Shell got {'DOWN',25307,process,<0.39.0>,{exit_status,15}}
 Shell got {'DOWN',25308,process,<0.41.0>,{exit_status,15}}
 ok

--- a/src/overview.edoc
+++ b/src/overview.edoc
@@ -63,6 +63,9 @@ sudo setcap cap_setuid,cap_kill,cap_sys_nice+eip _build/default/lib/erlexec/priv
     or a custom function. When redirected to a file, the file can be
     open in append/truncate mode, and given creation access mask.</li>
 <li>Run interactive processes with psudo-terminal pty support.</li>
+<li>Support all PTY options defined in the
+    [section-8](https://datatracker.ietf.org/doc/html/rfc4254#section-8)
+    of the [RFC4254](https://datatracker.ietf.org/doc/html/rfc4254).</li>
 <li>Execute OS processes under different user credentials (using Linux
     capabilities).</li>
 </ol>


### PR DESCRIPTION
> I agree that it would be great to support all modes mentioned in [section-8](https://datatracker.ietf.org/doc/html/rfc4254#section-8) of the RFC4254.

This is a follow-up for #158 which allows not only to disable or enable echo, but set arbitrary pty settings in the run command and also while a command is already running.
I'm not that proficient in C++ or Erlang, so it might not be the nicest code.