### PR TITLE
Replace INT_MAX with std::numeric_limits<int>::max()

### DIFF
--- a/c_src/ei++.hpp
+++ b/c_src/ei++.hpp
@@ -52,7 +52,7 @@
 #include <iostream>
 #include <sys/time.h>
 #include <sys/resource.h>
-#include <limits.h>
+#include <limits>
 #include <assert.h>
 
 #define NEW_FLOAT_EXT 'F'
@@ -68,7 +68,7 @@ namespace ei {
     /// @param <size> optional size of the <cmds> array.
     /// @return an offset <cmd> in the cmds array starting with <firstIdx> value. On failure
     ///         returns <firstIdx>-1.
-    int stringIndex(const char** cmds, const std::string& cmd, int firstIdx = 0, int size = INT_MAX);
+    int stringIndex(const char** cmds, const std::string& cmd, int firstIdx = 0, int size = std::numeric_limits<int>::max());
 
     /// Class for stack-based (and on-demand heap based) memory allocation
     /// of string buffers.  It's very efficient for strings not exceeding <N>

--- a/c_src/exec.cpp
+++ b/c_src/exec.cpp
@@ -78,7 +78,7 @@ int   ei::max_fds;
 int   ei::dev_null;
 int   ei::sigchld_pipe[2] = { -1, -1 }; // Pipe for delivering sig child details
 
-static int run_as_euid    = INT_MAX;
+static int run_as_euid    = std::numeric_limits<int>::max();
 
 //-------------------------------------------------------------------------
 // Types & variables

--- a/c_src/exec.hpp
+++ b/c_src/exec.hpp
@@ -39,7 +39,6 @@ enum class FdType {
 #include <sys/wait.h>
 #include <sys/time.h>
 #include <sys/resource.h>
-#include <limits.h>
 #include <grp.h>
 #include <pwd.h>
 #include <fcntl.h>
@@ -216,11 +215,11 @@ private:
     }
 
 public:
-    explicit CmdOptions(int def_user=INT_MAX)
+    explicit CmdOptions(int def_user=std::numeric_limits<int>::max())
         : m_tmp(0, 256)
         , m_is_kill_cmd(false)
-        , m_nice(INT_MAX)
-        , m_group(INT_MAX), m_user(def_user)
+        , m_nice(std::numeric_limits<int>::max())
+        , m_group(std::numeric_limits<int>::max()), m_user(def_user)
     {
         init_streams();
     }

--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -164,7 +164,7 @@ int set_nice(pid_t pid,int nice, std::string& error)
 {
     ei::StringBuffer<128> err;
 
-    if (nice != INT_MAX && setpriority(PRIO_PROCESS, pid, nice) < 0) {
+    if (nice != std::numeric_limits<int>::max() && setpriority(PRIO_PROCESS, pid, nice) < 0) {
         err.write("Cannot set priority of pid %d to %d", pid, nice);
         error = err.c_str();
         DEBUG(debug, "%s", error.c_str());
@@ -413,7 +413,7 @@ pid_t start_child(CmdOptions& op, std::string& error)
     if (debug || op.dbg()) {
         DEBUG(true, "Starting %s: '%s' (euid=%d)",
               op.is_kill_cmd() ? "custom kill command" : "child",
-              op.cmd().front().c_str(), op.user() == INT_MAX ? -1 : op.user());
+              op.cmd().front().c_str(), op.user() == std::numeric_limits<int>::max() ? -1 : op.user());
         if (!op.is_kill_cmd())
             fprintf(stderr,
                     "  child  = (stdin=%s, stdout=%s, stderr=%s)\r\n"
@@ -552,7 +552,7 @@ pid_t start_child(CmdOptions& op, std::string& error)
         }
 
         #if !defined(__CYGWIN__) && !defined(__WIN32)
-        if (op.user() != INT_MAX &&
+        if (op.user() != std::numeric_limits<int>::max() &&
             #ifdef HAVE_SETRESUID
                 setresuid(op.user(), op.user(), op.user())
             #elif HAVE_SETREUID
@@ -567,7 +567,7 @@ pid_t start_child(CmdOptions& op, std::string& error)
         }
         #endif
 
-        if (op.group() != INT_MAX && setpgid(0, op.group()) < 0) {
+        if (op.group() != std::numeric_limits<int>::max() && setpgid(0, op.group()) < 0) {
             err.write("Cannot set effective group to %d", op.group());
             perror(err.c_str());
             exit(EXIT_FAILURE);
@@ -638,7 +638,7 @@ pid_t start_child(CmdOptions& op, std::string& error)
     // group ID to the same value immediately after a fork(), and the
     // parent ignores any occurrence of the EACCES error on the setpgid() call.
 
-    if (op.group() != INT_MAX) {
+    if (op.group() != std::numeric_limits<int>::max()) {
         pid_t gid = op.group() ? op.group() : pid;
         if (setpgid(pid, gid) == -1 && errno != EACCES)
             DEBUG(debug, "  Parent failed to set group of pid %d to %d: %s",
@@ -707,9 +707,9 @@ int stop_child(CmdInfo& ci, int transId, const TimeVal& now, bool notify)
         kill_cmd.push_front(ci.kill_cmd.c_str());
         MapEnv env{{"CHILD_PID", std::to_string(ci.cmd_pid)}};
         CmdOptions co(kill_cmd, NULL, env,
-                      INT_MAX, // user
-                      INT_MAX, // nice
-                      INT_MAX, // group
+                      std::numeric_limits<int>::max(), // user
+                      std::numeric_limits<int>::max(), // nice
+                      std::numeric_limits<int>::max(), // group
                       true     // this is a custom kill command
                      );
 
@@ -876,7 +876,7 @@ int check_children(const TimeVal& now, bool& isTerminated, bool notify)
 
         if (i != children.end()) {
             for(int stream_id=STDOUT_FILENO; stream_id <= STDERR_FILENO; ++stream_id)
-                process_pid_output(i->second, stream_id, INT_MAX);
+                process_pid_output(i->second, stream_id, std::numeric_limits<int>::max());
             // Override status code if termination was requested by Erlang
             PidStatusT ps(it->first,
                 i->second.sigterm
@@ -885,7 +885,7 @@ int check_children(const TimeVal& now, bool& isTerminated, bool notify)
                     ? i->second.success_code // Override success status code
                     : it->second);
             // The process exited and it requires to kill all other processes in the group
-            if (i->second.kill_group && i->second.cmd_gid != INT_MAX && i->second.cmd_gid)
+            if (i->second.kill_group && i->second.cmd_gid != std::numeric_limits<int>::max() && i->second.cmd_gid)
                 erl_exec_kill(-(i->second.cmd_gid), SIGTERM, SRCLOC); // Kill all children in this group
 
             if (notify && send_pid_status_term(ps) < 0) {
@@ -1182,7 +1182,7 @@ int CmdOptions::ei_decode(bool getcmd)
     m_kill_cmd.clear();
     m_env.clear();
 
-    m_nice = INT_MAX;
+    m_nice = std::numeric_limits<int>::max();
 
     if (getcmd) {
         std::string s;


### PR DESCRIPTION
So my goal is to use `erlexec` on embedded devices using Elixir's Nerves project for interactive shells (https://github.com/SteffenDE/nerves_ssh_shell) and on musl based systems it complains about `limits.h` missing:

```bash
===> Compiling /Users/steffen/Desktop/MonitorNews/nerves_containers/nerves_ssh_shell/examples/ssh_multi_daemon_example/deps/erlexec/c_src/ei++.cpp
===> In file included from c_src/ei++.hpp:50,
                 from c_src/ei++.cpp:5:
/Users/steffen/.nerves/artifacts/nerves_system_x86_64-portable-1.20.0/staging/usr/include/limits.h:124:26: error: no include path in which to search for limits.h
  124 | # include_next <limits.h>
      |                          ^
In file included from c_src/ei++.cpp:5:
c_src/ei++.hpp:76:28: error: 'INT_MAX' was not declared in this scope
   76 |                 int size = INT_MAX);
      |                            ^~~~~~~
c_src/ei++.hpp:57:1: note: 'INT_MAX' is defined in header '<climits>'; did you forget to '#include <climits>'?
   56 | #include <sys/time.h>
  +++ |+#include <climits>
   57 | #include <unistd.h>
```

Including `climits` does NOT help, but replacing the occurrences of `INT_MAX` with `std::numeric_limits<int>::max()` works fine.

What do you think?