### PR TITLE
fix tty_speed setting

### DIFF
--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -208,9 +208,17 @@ bool set_pty_opt(struct termios* tio, const std::string& key, int value) {
         return true;                                                           \
     }
 
-#define TTYSPEED(NAME, FIELD, STR_NAME)                                        \
-    if (key == STR_NAME) {                                                     \
-        if (tio) tio->FIELD = value;                                           \
+#define TTYSPEED(VALUE)                                                        \
+    if (key == "tty_op_ispeed" && value == VALUE) {                            \
+        if (tio) {                                                             \
+            return cfsetispeed(tio, value) == 0;                               \
+        }                                                                      \
+        return true;                                                           \
+    }                                                                          \
+    if (key == "tty_op_ospeed" && value == VALUE) {                            \
+        if (tio) {                                                             \
+            return cfsetospeed(tio, value) == 0;                               \
+        }                                                                      \
         return true;                                                           \
     }
 

--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -211,17 +211,11 @@ bool set_pty_opt(struct termios* tio, const std::string& key, int value) {
 #define TTYSPEED(VALUE)                                                        \
     if (key == "tty_op_ispeed" && value == VALUE) {                            \
         DEBUG(debug, "set tty_ispeed %d\r\n", value);                          \
-        if (tio) {                                                             \
-            return cfsetispeed(tio, value) == 0;                               \
-        }                                                                      \
-        return true;                                                           \
+        return !tio || cfsetispeed(tio, value) == 0;                           \
     }                                                                          \
     if (key == "tty_op_ospeed" && value == VALUE) {                            \
         DEBUG(debug, "set tty_ospeed %d\r\n", value);                          \
-        if (tio) {                                                             \
-            return cfsetospeed(tio, value) == 0;                               \
-        }                                                                      \
-        return true;                                                           \
+        return !tio || cfsetospeed(tio, value) == 0;                           \
     }
 
 #include "ttymodes.hpp"

--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -210,12 +210,14 @@ bool set_pty_opt(struct termios* tio, const std::string& key, int value) {
 
 #define TTYSPEED(VALUE)                                                        \
     if (key == "tty_op_ispeed" && value == VALUE) {                            \
+        DEBUG(debug, "set tty_ispeed %d\r\n", value);                          \
         if (tio) {                                                             \
             return cfsetispeed(tio, value) == 0;                               \
         }                                                                      \
         return true;                                                           \
     }                                                                          \
     if (key == "tty_op_ospeed" && value == VALUE) {                            \
+        DEBUG(debug, "set tty_ospeed %d\r\n", value);                          \
         if (tio) {                                                             \
             return cfsetospeed(tio, value) == 0;                               \
         }                                                                      \

--- a/c_src/ttymodes.hpp
+++ b/c_src/ttymodes.hpp
@@ -115,19 +115,85 @@ TTYMODE(CS8,     c_cflag, "cs8")
 TTYMODE(PARENB,  c_cflag, "parenb")
 TTYMODE(PARODD,  c_cflag, "parodd")
 
-/* name, field, atom */
-#ifdef c_ispeed
-TTYSPEED(TTY_OP_ISPEED, c_ispeed,   "tty_op_ispeed")
+/* speed */
+#ifdef B0
+TTYSPEED(B0)
 #endif
-
-#ifdef __c_ispeed
-TTYSPEED(TTY_OP_ISPEED, __c_ispeed, "tty_op_ispeed")
+#ifdef B50
+TTYSPEED(B50)
 #endif
-
-#ifdef c_ospeed
-TTYSPEED(TTY_OP_OSPEED, c_ospeed,   "tty_op_ospeed")
+#ifdef B75
+TTYSPEED(B75)
 #endif
-
-#ifdef __c_ospeed
-TTYSPEED(TTY_OP_OSPEED, __c_ospeed, "tty_op_ospeed")
+#ifdef B110
+TTYSPEED(B110)
+#endif
+#ifdef B134
+TTYSPEED(B134)
+#endif
+#ifdef B150
+TTYSPEED(B150)
+#endif
+#ifdef B200
+TTYSPEED(B200)
+#endif
+#ifdef B300
+TTYSPEED(B300)
+#endif
+#ifdef B600
+TTYSPEED(B600)
+#endif
+#ifdef B1200
+TTYSPEED(B1200)
+#endif
+#ifdef B1800
+TTYSPEED(B1800)
+#endif
+#ifdef B2400
+TTYSPEED(B2400)
+#endif
+#ifdef B4800
+TTYSPEED(B4800)
+#endif
+#ifdef B9600
+TTYSPEED(B9600)
+#endif
+#ifdef B19200
+TTYSPEED(B19200)
+#endif
+#ifdef B38400
+TTYSPEED(B38400)
+#endif
+#ifdef B57600
+TTYSPEED(B57600)
+#endif
+#ifdef B115200
+TTYSPEED(B115200)
+#endif
+#ifdef B230400
+TTYSPEED(B230400)
+#endif
+#ifdef B460800
+TTYSPEED(B460800)
+#endif
+#ifdef B500000
+TTYSPEED(B500000)
+#endif
+#ifdef B576000
+TTYSPEED(B576000)
+#endif
+#ifdef B921600
+TTYSPEED(B921600)
+#endif
+#ifdef B1000000
+TTYSPEED(B1000000)
+#endif
+#ifdef B1152000
+TTYSPEED(B1152000)
+#endif
+#ifdef B1500000
+TTYSPEED(B1500000)
+#endif
+#ifdef B200000
+TTYSPEED(B2000000)
 #endif


### PR DESCRIPTION
I came across this issue in my `nerves_ssh_shell` project:

```
** (FunctionClauseError) no function clause matching in anonymous fn/1 in NervesSSH.SystemShell.exec_command/2
    (nerves_ssh 0.4.0) lib/nerves_ssh/system_shell.ex:74: anonymous fn({:error, 'pty - invalid pty argument \'tty_op_ospeed\''}) in NervesSSH.SystemShell.exec_command/2
```

In there I currently just forward the options from the erlang ssh [pty_ch_msg](https://www.erlang.org/doc/man/ssh_connection.html#type-pty_ch_msg) to erlexec. This does not work if an option is not supported by the system. In this case it's a bug. I added the `__c_ispeed` and `__c_ospeed` checks for musl based systems, but these are struct members and not defined as macros. This commit replaces the way tty speeds are handled to use the posix `cfsetispeed` and `cfsetospeed` functions.

Generally, I think that maybe there should be a graceful error on `:exec.run` when there's an error while setting a pty option. Because of all the `ifdefs` in `ttymodes.hpp` there could very well be the case that SSH requests a setting that the system does not support. Rather to fail hard, maybe it should only fail if all options failed to set? Otherwise the only option for me would be to set each option one by one **after** starting the process.
Quoting from the termios man page:

> Note that tcsetattr() returns success if any of the requested changes could be successfully carried out. Therefore, when making multiple changes it may be necessary to follow this call with a further call to tcgetattr() to check that all changes have been performed successfully.

Therefore, I think it's reasonable to only fail if there was no change at all.