### PR TITLE
Do not fail if a pty_opt is not implemented on exec:run

### DIFF
--- a/c_src/exec.cpp
+++ b/c_src/exec.cpp
@@ -506,11 +506,6 @@ bool process_command(bool is_err)
                     return true;
                 }
 
-                if (!validate_pty_opt(key, val)) {
-                    send_error_str(transId, false, "invalid pty option %s or value", key.c_str());
-                    return true;
-                }
-
                 if (!set_pty_opt(&ios, key, val)) {
                     send_error_str(transId, false, "failed to set pty option %s", key.c_str());
                     return true;

--- a/c_src/exec.cpp
+++ b/c_src/exec.cpp
@@ -506,8 +506,13 @@ bool process_command(bool is_err)
                     return true;
                 }
 
+                if (!validate_pty_opt(key, val)) {
+                    send_error_str(transId, false, "invalid pty option %s or value", key.c_str());
+                    return true;
+                }
+
                 if (!set_pty_opt(&ios, key, val)) {
-                    send_error_str(transId, false, "invalid pty option %s", key.c_str());
+                    send_error_str(transId, false, "failed to set pty option %s", key.c_str());
                     return true;
                 }
             }

--- a/c_src/exec.hpp
+++ b/c_src/exec.hpp
@@ -371,7 +371,6 @@ int     set_euid(int userid);
 int     set_nice(pid_t pid,int nice, std::string& error);
 bool    process_sigchld();
 bool    set_pid_winsz(CmdInfo& ci, int rows, int cols);
-bool    validate_pty_opt(const std::string& key, int value);
 bool    set_pty_opt(struct termios* tio, const std::string& key, int value);
 bool    set_cloexec_flag(int fd, bool value);
 bool    process_pid_input(CmdInfo& ci);

--- a/c_src/exec.hpp
+++ b/c_src/exec.hpp
@@ -371,6 +371,7 @@ int     set_euid(int userid);
 int     set_nice(pid_t pid,int nice, std::string& error);
 bool    process_sigchld();
 bool    set_pid_winsz(CmdInfo& ci, int rows, int cols);
+bool    validate_pty_opt(const std::string& key, int value);
 bool    set_pty_opt(struct termios* tio, const std::string& key, int value);
 bool    set_cloexec_flag(int fd, bool value);
 bool    process_pid_input(CmdInfo& ci);

--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -188,6 +188,36 @@ bool set_pid_winsz(CmdInfo& ci, int rows, int cols)
 }
 
 //------------------------------------------------------------------------------
+bool validate_pty_opt(const std::string& key, int value) {
+    // keep this in sync with the type definition in exec.erl
+    const std::string tty_chars[] = {
+        "vintr", "vquit", "verase", "vkill", "veof",
+        "veol", "veol2", "vstart", "vstop", "vsusp",
+        "vdsusp", "vreprint", "vwerase", "vlnext",
+        "vflush", "vswtch", "vstatus", "vdiscard"
+    };
+    const std::string tty_modes[] = {
+        "ignpar", "parmrk", "inpck", "istrip", "inlcr",
+        "igncr", "icrnl", "xcase", "iuclc", "ixon", "ixany",
+        "ixoff", "imaxbel", "iutf8", "isig", "icanon",
+        "echo", "echoe", "echok", "echonl", "noflsh",
+        "tostop", "iexten", "echoctl", "echoke", "pendin",
+        "opost", "olcuc", "onlcr", "ocrnl", "onocr",
+        "onlret", "cs7", "cs8", "parenb", "parodd"
+    };
+    // special characters must be between 0 and 255
+    if (std::find(std::begin(tty_chars), std::end(tty_chars), key) != std::end(tty_chars)) {
+        return value >= 0 && value <= 255;
+    }
+    // modes must be either enabled or disabled
+    if (std::find(std::begin(tty_modes), std::end(tty_modes), key) != std::end(tty_modes)) {
+        return value == 0 || value == 1;
+    }
+    // only valid remaining options are speed
+    return key == "tty_op_ispeed" || key == "tty_op_ospeed";
+}
+
+//------------------------------------------------------------------------------
 bool set_pty_opt(struct termios* tio, const std::string& key, int value) {
 #define TTYCHAR(NAME, STR_NAME)                                                \
     if (key == STR_NAME) {                                                     \
@@ -223,6 +253,17 @@ bool set_pty_opt(struct termios* tio, const std::string& key, int value) {
 #undef TTYCHAR
 #undef TTYMODE
 #undef TTYSPEED
+
+    // fallback for systems without pre-defined baud rates
+    if (key == "tty_op_ispeed") {
+        DEBUG(debug, "set tty_ispeed %d\r\n", value);
+        return !tio || cfsetispeed(tio, value) == 0;
+    }
+    if (key == "tty_op_ospeed") {
+        DEBUG(debug, "set tty_ospeed %d\r\n", value);
+        return !tio || cfsetospeed(tio, value) == 0;
+    }
+
     return false;
 }
 
@@ -1414,9 +1455,9 @@ int CmdOptions::ei_decode(bool getcmd)
                     int         val;
 
                     if (eis.decodeTupleSize() != 2 || eis.decodeAtom(key) < 0 || key.empty() ||
-                        !eis.decodeIntOrBool(val)  || !set_pty_opt(nullptr, key, val))
+                        !eis.decodeIntOrBool(val)  || !validate_pty_opt(key, val))
                     {
-                        m_err << op << " - invalid pty argument ";
+                        m_err << op << " - invalid pty argument or value ";
                         if (!key.empty()) m_err << "'" << key << "'";
                         else              m_err << "#" << i;
                         return -1;

--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -188,36 +188,6 @@ bool set_pid_winsz(CmdInfo& ci, int rows, int cols)
 }
 
 //------------------------------------------------------------------------------
-bool validate_pty_opt(const std::string& key, int value) {
-    // keep this in sync with the type definition in exec.erl
-    const std::string tty_chars[] = {
-        "vintr", "vquit", "verase", "vkill", "veof",
-        "veol", "veol2", "vstart", "vstop", "vsusp",
-        "vdsusp", "vreprint", "vwerase", "vlnext",
-        "vflush", "vswtch", "vstatus", "vdiscard"
-    };
-    const std::string tty_modes[] = {
-        "ignpar", "parmrk", "inpck", "istrip", "inlcr",
-        "igncr", "icrnl", "xcase", "iuclc", "ixon", "ixany",
-        "ixoff", "imaxbel", "iutf8", "isig", "icanon",
-        "echo", "echoe", "echok", "echonl", "noflsh",
-        "tostop", "iexten", "echoctl", "echoke", "pendin",
-        "opost", "olcuc", "onlcr", "ocrnl", "onocr",
-        "onlret", "cs7", "cs8", "parenb", "parodd"
-    };
-    // special characters must be between 0 and 255
-    if (std::find(std::begin(tty_chars), std::end(tty_chars), key) != std::end(tty_chars)) {
-        return value >= 0 && value <= 255;
-    }
-    // modes must be either enabled or disabled
-    if (std::find(std::begin(tty_modes), std::end(tty_modes), key) != std::end(tty_modes)) {
-        return value == 0 || value == 1;
-    }
-    // only valid remaining options are speed
-    return key == "tty_op_ispeed" || key == "tty_op_ospeed";
-}
-
-//------------------------------------------------------------------------------
 bool set_pty_opt(struct termios* tio, const std::string& key, int value) {
 #define TTYCHAR(NAME, STR_NAME)                                                \
     if (key == STR_NAME) {                                                     \
@@ -1455,7 +1425,7 @@ int CmdOptions::ei_decode(bool getcmd)
                     int         val;
 
                     if (eis.decodeTupleSize() != 2 || eis.decodeAtom(key) < 0 || key.empty() ||
-                        !eis.decodeIntOrBool(val)  || !validate_pty_opt(key, val))
+                        !eis.decodeIntOrBool(val))
                     {
                         m_err << op << " - invalid pty argument or value ";
                         if (!key.empty()) m_err << "'" << key << "'";

--- a/src/exec.erl
+++ b/src/exec.erl
@@ -1402,7 +1402,7 @@ check_pty_opt(_,             _) -> false.
 
 is_byte(V)  -> V >= 0 andalso V =< 255.
 is_mode(V)  -> is_boolean(V) orelse V==0 orelse V==1.
-is_speed(V) -> is_integer(Val) andalso Val >= 0.
+is_speed(V) -> is_integer(V) andalso V >= 0.
 
 next_trans(I) when I =< 134217727 ->
     I+1;

--- a/src/exec.erl
+++ b/src/exec.erl
@@ -1339,73 +1339,70 @@ check_pty_opts(Pty) when is_list(Pty) ->
     L  -> throw({error, {invalid_pty_value, L}})
     end.
 
-check_pty_opt(Key, Val) ->
-    if
-        % special characters
-        Key =:= vintr;
-        Key =:= vquit;
-        Key =:= verase;
-        Key =:= vkill;
-        Key =:= veof;
-        Key =:= veol;
-        Key =:= veol2;
-        Key =:= vstart;
-        Key =:= vstop;
-        Key =:= vsusp;
-        Key =:= vdsusp;
-        Key =:= vreprint;
-        Key =:= vwerase;
-        Key =:= vlnext;
-        Key =:= vflush;
-        Key =:= vswtch;
-        Key =:= vstatus;
-        Key =:= vdiscard ->
-            Val >= 0 andalso Val =< 255;
-        % modes
-        Key =:= ignpar;
-        Key =:= parmrk;
-        Key =:= inpck;
-        Key =:= istrip;
-        Key =:= inlcr;
-        Key =:= igncr;
-        Key =:= icrnl;
-        Key =:= xcase;
-        Key =:= iuclc;
-        Key =:= ixon;
-        Key =:= ixany;
-        Key =:= ixoff;
-        Key =:= imaxbel;
-        Key =:= iutf8;
-        Key =:= isig;
-        Key =:= icanon;
-        Key =:= echo;
-        Key =:= echoe;
-        Key =:= echok;
-        Key =:= echonl;
-        Key =:= noflsh;
-        Key =:= tostop;
-        Key =:= iexten;
-        Key =:= echoctl;
-        Key =:= echoke;
-        Key =:= pendin;
-        Key =:= opost;
-        Key =:= olcuc;
-        Key =:= onlcr;
-        Key =:= ocrnl;
-        Key =:= onocr;
-        Key =:= onlret;
-        Key =:= cs7;
-        Key =:= cs8;
-        Key =:= parenb;
-        Key =:= parodd ->
-            Val =:= 0 orelse Val =:= 1 orelse Val =:= true orelse Val =:= false;
-        % speed
-        Key =:= tty_op_ispeed; Key =:= tty_op_ospeed ->
-            is_integer(Val) andalso Val >= 0;
-        % invalid
-        true ->
-            false
-    end.
+%% special characters
+check_pty_opt(vintr,    V) -> is_byte(V);
+check_pty_opt(vquit,    V) -> is_byte(V);
+check_pty_opt(verase,   V) -> is_byte(V);
+check_pty_opt(vkill,    V) -> is_byte(V);
+check_pty_opt(veof,     V) -> is_byte(V);
+check_pty_opt(veol,     V) -> is_byte(V);
+check_pty_opt(veol2,    V) -> is_byte(V);
+check_pty_opt(vstart,   V) -> is_byte(V);
+check_pty_opt(vstop,    V) -> is_byte(V);
+check_pty_opt(vsusp,    V) -> is_byte(V);
+check_pty_opt(vdsusp,   V) -> is_byte(V);
+check_pty_opt(vreprint, V) -> is_byte(V);
+check_pty_opt(vwerase,  V) -> is_byte(V);
+check_pty_opt(vlnext,   V) -> is_byte(V);
+check_pty_opt(vflush,   V) -> is_byte(V);
+check_pty_opt(vswtch,   V) -> is_byte(V);
+check_pty_opt(vstatus,  V) -> is_byte(V);
+check_pty_opt(vdiscard, V) -> is_byte(V);
+%% modes
+check_pty_opt(ignpar,   V) -> is_mode(V);
+check_pty_opt(parmrk,   V) -> is_mode(V);
+check_pty_opt(inpck,    V) -> is_mode(V);
+check_pty_opt(istrip,   V) -> is_mode(V);
+check_pty_opt(inlcr,    V) -> is_mode(V);
+check_pty_opt(igncr,    V) -> is_mode(V);
+check_pty_opt(icrnl,    V) -> is_mode(V);
+check_pty_opt(xcase,    V) -> is_mode(V);
+check_pty_opt(iuclc,    V) -> is_mode(V);
+check_pty_opt(ixon,     V) -> is_mode(V);
+check_pty_opt(ixany,    V) -> is_mode(V);
+check_pty_opt(ixoff,    V) -> is_mode(V);
+check_pty_opt(imaxbel,  V) -> is_mode(V);
+check_pty_opt(iutf8,    V) -> is_mode(V);
+check_pty_opt(isig,     V) -> is_mode(V);
+check_pty_opt(icanon,   V) -> is_mode(V);
+check_pty_opt(echo,     V) -> is_mode(V);
+check_pty_opt(echoe,    V) -> is_mode(V);
+check_pty_opt(echok,    V) -> is_mode(V);
+check_pty_opt(echonl,   V) -> is_mode(V);
+check_pty_opt(noflsh,   V) -> is_mode(V);
+check_pty_opt(tostop,   V) -> is_mode(V);
+check_pty_opt(iexten,   V) -> is_mode(V);
+check_pty_opt(echoctl,  V) -> is_mode(V);
+check_pty_opt(echoke,   V) -> is_mode(V);
+check_pty_opt(pendin,   V) -> is_mode(V);
+check_pty_opt(opost,    V) -> is_mode(V);
+check_pty_opt(olcuc,    V) -> is_mode(V);
+check_pty_opt(onlcr,    V) -> is_mode(V);
+check_pty_opt(ocrnl,    V) -> is_mode(V);
+check_pty_opt(onocr,    V) -> is_mode(V);
+check_pty_opt(onlret,   V) -> is_mode(V);
+check_pty_opt(cs7,      V) -> is_mode(V);
+check_pty_opt(cs8,      V) -> is_mode(V);
+check_pty_opt(parenb,   V) -> is_mode(V);
+check_pty_opt(parodd,   V) -> is_mode(V);
+% speed
+check_pty_opt(tty_op_ispeed, V) -> is_speed(V);
+check_pty_opt(tty_op_ospeed, V) -> is_speed(V);
+check_pty_opt(_,             _) -> false.
+
+is_byte(V)  -> V >= 0 andalso V =< 255.
+is_mode(V)  -> is_boolean(V) orelse V==0 orelse V==1.
+is_speed(V) -> is_integer(Val) andalso Val >= 0.
 
 next_trans(I) when I =< 134217727 ->
     I+1;


### PR DESCRIPTION
This PR addresses multiple issues.

First it adds a separate pty opt validation to the C++ side separate from the `set_pty_opt` function. Previously it could happen that a client sends an option that is not implemented in the system, as described in https://github.com/saleyn/erlexec/pull/162. One example is `olcuc` on macOS. This now only fails when dynamically setting the option using `exec:pty_opts` but not on `exec:run`.

Second, we try to set the pty speed on systems that do not have pre-defined baud constants.

Finally, it should fix #160 - the pty tests did not expect the two `test\r\n` strings to arrive in a single message.

What do you think? If you want I can also split this PR.