### PR TITLE
Close stdin by eof after consuming stdin_queue

### DIFF
--- a/c_src/exec.cpp
+++ b/c_src/exec.cpp
@@ -543,7 +543,8 @@ bool process_command(bool is_err)
             }
 
             if (eof) {
-                close_stdin(it->second);
+                it->second.eof_arrived = true;
+                process_pid_input(it->second);
                 break;
             }
 

--- a/c_src/exec.hpp
+++ b/c_src/exec.hpp
@@ -304,26 +304,28 @@ public:
 /// structure will contain its run-time information.
 //-------------------------------------------------------------------------
 struct CmdInfo {
-    CmdArgsList     cmd;               // Executed command
-    pid_t           cmd_pid;           // Pid of the custom kill command
-    pid_t           cmd_gid;           // Command's group ID
-    std::string     kill_cmd;          // Kill command to use (default: use SIGTERM)
-    kill_cmd_pid_t  kill_cmd_pid = -1; // Pid of the command that <pid> is supposed to kill
-    ei::TimeVal     deadline;          // Time when the <cmd_pid> is supposed to be killed using SIGTERM.
-    bool            sigterm = false;   // <true> if sigterm was issued.
-    bool            sigkill = false;   // <true> if sigkill was issued.
-    int             kill_timeout;      // Pid shutdown interval in sec before it's killed with SIGKILL
-    bool            kill_group;        // Indicates if at exit the whole group needs to be killed
-    int             success_code;      // Exit code to use on success
-    bool            managed;           // <true> if this pid is started externally, but managed by erlexec
-    int             stream_fd[3];      // Pipe fd getting   process's stdin/stdout/stderr
-    int             stdin_wr_pos = 0;  // Offset of the unwritten portion of the head item of stdin_queue
-    int             dbg = 0;           // Debug flag
-#if defined(USE_POLL) && USE_POLL > 0
+    using Queue = std::list<std::string>;
+    
+    CmdArgsList     cmd;                // Executed command
+    pid_t           cmd_pid;            // Pid of the custom kill command
+    pid_t           cmd_gid;            // Command's group ID
+    std::string     kill_cmd;           // Kill command to use (default: use SIGTERM)
+    kill_cmd_pid_t  kill_cmd_pid   = -1;// Pid of the command that <pid> is supposed to kill
+    ei::TimeVal     deadline;           // Time when the <cmd_pid> is supposed to be killed using SIGTERM.
+    bool            sigterm = false;    // <true> if sigterm was issued.
+    bool            sigkill = false;    // <true> if sigkill was issued.
+    int             kill_timeout;       // Pid shutdown interval in sec before it's killed with SIGKILL
+    bool            kill_group;         // Indicates if at exit the whole group needs to be killed
+    int             success_code;       // Exit code to use on success
+    bool            managed;            // <true> if this pid is started externally, but managed by erlexec
+    int             stream_fd[3];       // Pipe fd getting   process's stdin/stdout/stderr
+    int             stdin_wr_pos   = 0; // Offset of the unwritten portion of the head item of stdin_queue
+    int             dbg            = 0; // Debug flag
+    Queue           stdin_queue;
+    bool            eof_arrived    = false;
+#if defined(USE_POLL) && USE_POLL  > 0
     int             poll_fd_idx[3] = {-1,-1,-1}; // Indexes to the pollfd structure in the poll array
 #endif
-    std::list<std::string> stdin_queue;
-    bool eof_arrived = false;
 
     // delete default constructor, copy-ctor and assignment operator
     CmdInfo() = delete;

--- a/c_src/exec.hpp
+++ b/c_src/exec.hpp
@@ -323,6 +323,7 @@ struct CmdInfo {
     int             poll_fd_idx[3] = {-1,-1,-1}; // Indexes to the pollfd structure in the poll array
 #endif
     std::list<std::string> stdin_queue;
+    bool eof_arrived = false;
 
     // delete default constructor, copy-ctor and assignment operator
     CmdInfo() = delete;

--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -290,6 +290,10 @@ bool process_pid_input(CmdInfo& ci)
         ci.stdin_wr_pos = 0;
     }
 
+    if (ci.stdin_queue.empty() && ci.eof_arrived) {
+        close_stdin(ci);
+    }
+
     return true;
 }
 


### PR DESCRIPTION
In my understanding, the current erlexec throws away the queued inputs in `stdin_queue` and closes stdin immediately after `eof` comes. However, the library user sent `eof` to the erlexec's process after he/she sent the queued inputs. Therefore, I believe stdin should be closed after all the queued inputs are consumed. I implemented this behavior in this PR.