### PR TITLE
Propogate capabilities to child process

### DIFF
--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -365,6 +365,47 @@ static int getpty(int& fdmp, ei::StringBuffer<128>& err) {
 }
 
 #ifdef HAVE_CAP
+// Placeholder for atom declaration
+// sed -n 's/^#define \(CAP_.*\) .*/\1/p' /usr/include/linux/capability.h | tr A-Z a-z | sed 's/cap_//'
+//
+const char *cap_name[CAP_LAST_CAP+1] = {
+    "chown",
+    "dac_override",
+    "dac_read_search",
+    "fowner",
+    "fsetid",
+    "kill",
+    "setgid",
+    "setuid",
+    "setpcap",
+    "linux_immutable",
+    "net_bind_service",
+    "net_broadcast",
+    "net_admin",
+    "net_raw",
+    "ipc_lock",
+    "ipc_owner",
+    "sys_module",
+    "sys_rawio",
+    "sys_chroot",
+    "sys_ptrace",
+    "sys_pacct",
+    "sys_admin",
+    "sys_boot",
+    "sys_nice",
+    "sys_resource",
+    "sys_time",
+    "sys_tty_config",
+    "mknod",
+    "lease",
+    "audit_write",
+    "audit_control",
+    "setfcap",
+    "mac_override",
+    "mac_admin",
+    "syslog"
+};
+
 struct Caps {
     Caps() : m_caps(cap_get_proc()) {}
     ~Caps() { if (m_caps) cap_free(m_caps); }

--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -365,6 +365,55 @@ static int getpty(int& fdmp, ei::StringBuffer<128>& err) {
 }
 
 //------------------------------------------------------------------------------
+void propagate_caps(ei::StringBuffer<128>& err)
+{
+#ifdef HAVE_CAP
+    cap_t caps;
+    cap_value_t cap_list[CAP_LAST_CAP + 1];
+    int num_caps=0;
+
+    // Get the current process capabilities
+    caps = cap_get_proc();
+    if (caps == NULL) {
+        err.write("error %d on cap_get_proc: %s\n", errno, strerror(errno));
+    }
+
+    // Get the bounding set of capabilities
+    cap_flag_value_t cap_value;
+    for (cap_value_t i = 0; i <= CAP_LAST_CAP; ++i) {
+        if (cap_get_flag(caps, i, CAP_PERMITTED, &cap_value) == -1) {
+            err.write("error %d on cap_get_flag: %s\n", errno, strerror(errno));
+        }
+        if (cap_value == CAP_SET) {
+            cap_list[num_caps++] = i;
+        }
+    }
+
+    // Set inheritable capabilities to all permitted capabilities
+    if (cap_set_flag(caps, CAP_INHERITABLE, num_caps, cap_list, CAP_SET) == -1) {
+        err.write("error %d on cap_set_flag: %s\n", errno, strerror(errno));
+    }
+
+    // Apply inheritable capabilities
+    if (cap_set_proc(caps) == -1) {
+        err.write("error %d on cap_set_proc: %s\n", errno, strerror(errno));
+    }
+
+    // Set ambient capabilities
+    for (size_t i = 0; i < num_caps; i++) {
+        if (prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, cap_list[i], 0, 0) == -1) {
+            err.write("error %d on PR_CAP_AMBIENT_RAISE: %s\n", errno, strerror(errno));
+        }
+    }
+
+    // Free the capability state
+    if (cap_free(caps) == -1) {
+        err.write("error %d on cap_free: %s\n", errno, strerror(errno));
+    }
+#endif
+}
+
+//------------------------------------------------------------------------------
 pid_t start_child(CmdOptions& op, std::string& error)
 {
     enum { RD = 0, WR = 1 };
@@ -489,7 +538,6 @@ pid_t start_child(CmdOptions& op, std::string& error)
     } else if (pid == 0) {
         // I am the child
         int r;
-        
         if (op.pty()) {
             int fds;
             char pts_name[256];
@@ -646,6 +694,8 @@ pid_t start_child(CmdOptions& op, std::string& error)
                 fprintf(stderr, "  CEnv: %s\r\n", p);
         }
         */
+
+        propagate_caps(err);
 
         const char* executable = op.executable().empty()
             ? argv[0] : op.executable().c_str();

--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -365,7 +365,7 @@ static int getpty(int& fdmp, ei::StringBuffer<128>& err) {
 }
 
 #ifdef HAVE_CAP
-// Placeholder for atom declaration
+// Placeholder for decoding capability names passed in the "run child" command
 // sed -n 's/^#define \(CAP_.*\) .*/\1/p' /usr/include/linux/capability.h | tr A-Z a-z | sed 's/cap_//'
 //
 const char *cap_name[CAP_LAST_CAP+1] = {
@@ -403,7 +403,9 @@ const char *cap_name[CAP_LAST_CAP+1] = {
     "setfcap",
     "mac_override",
     "mac_admin",
-    "syslog"
+    "syslog",
+    "wake_alarm",
+    "block_suspend",
 };
 
 struct Caps {

--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -364,6 +364,7 @@ static int getpty(int& fdmp, ei::StringBuffer<128>& err) {
     return 0;
 }
 
+#ifdef HAVE_CAP
 struct Caps {
     Caps() : m_caps(cap_get_proc()) {}
     ~Caps() { if (m_caps) cap_free(m_caps); }
@@ -377,6 +378,7 @@ private:
     cap_t m_caps;
     std::vector<cap_value_t> m_cap_list;
 };
+#endif
 
 //------------------------------------------------------------------------------
 bool propagate_caps(ei::StringBuffer<128>& err)


### PR DESCRIPTION
This is not ready to commit, but just an idea I wanted to share. 

Capabilities aren't shared with processes started via execve, unless you specifically manipulate the inherited capabilities before and then request the ambient capabilities to be raised

The motivation is that it's sometimes useful to be able to have erlang run commands with elevated capabilities, rather than jumping through sudo (one reason for this is that sudo is quite slow on my platform, adding around 30ms to every call, which for multiple calls is unreasonably slow). An example might be calling "ipset", normally this requires root permissions, but can be run as a non priv user if given cap_net_admin capabilities. 

So on my embedded box I am marking the erlexec binary with appropriate capabilities, and these can then be passed to the binary we want to run

I suspect to complete this you might want to make the inheritance of the capabilities optional?

Note also, I *think*, but haven't tested, that this will work as expected with change in effective UID? There are some pitfalls though as capabilities get dropped when changing uid, so I might need to split the code and read the caps before changing uid? Unsure?

However, what's your opinion? Is this useful upstream?