### PR TITLE
Drop "-g" flag from default options to reduce "exec-port" binary size

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -7,7 +7,7 @@ CXX       ?= g++
 ERL_CXXFLAGS ?= $(shell erl -noshell -noinput -eval 'io:format("-I~ts/erts-~ts/include -I~ts", [code:root_dir(), erlang:system_info(version), code:lib_dir(erl_interface, include)]), halt(0).')
 ERL_LDFLAGS  ?= $(shell erl -noshell -noinput -eval 'io:format("-L~ts", [code:lib_dir(erl_interface, lib)]), halt(0).')
 
-CXXFLAGS  += -g -std=c++11 -finline-functions -Wall -DHAVE_PTRACE -MMD
+CXXFLAGS  += -std=c++11 -finline-functions -Wall -DHAVE_PTRACE -MMD
 USE_POLL  ?= 1
 
 UNAME_SYS := $(shell uname -s | tr 'A-Z' 'a-z')


### PR DESCRIPTION
Hi @saleyn 

This PR related to the issue described [here](https://github.com/saleyn/erlexec/issues/182).

The idea is to reduce `exec-port` size in general, and especially when deploying on `Docker` where size matters:

```bash
# with "-g"
priv/x86_64-pc-linux-gnu/exec-port -> 1.9M

# without "-g"
priv/x86_64-pc-linux-gnu/exec-port -> 201k
```

Thanks
/Z