### PR TITLE
Fix for DragonFly

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you find this project useful, please donate to:
 
 ## Supported Platforms
 
-Linux, Solaris, FreeBSD, OpenBSD, MacOS X
+Linux, Solaris, FreeBSD, DragonFly, OpenBSD, MacOS X
 
 ## DOCUMENTATION ##
 

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -91,7 +91,7 @@ else ifeq ($(UNAME_SYS),darwin)
 else ifeq ($(uname_sys),solaris)
   CXXFLAGS += -dhave_setreuid
   LDFLAGS  += -lrt $(x64)
-else ifneq ($(filter $(UNAME_SYS),freebsd openbsd dradonfly),)
+else ifneq ($(filter $(UNAME_SYS),freebsd openbsd dragonfly),)
   CXXFLAGS += -DHAVE_SETRESUID -DHAVE_PIPE2 $(X64)
   LDFLAGS  += $(X64)
 else

--- a/rebar.config
+++ b/rebar.config
@@ -5,11 +5,11 @@
 ]}.
 
 {pre_hooks,  [
-  {"(freebsd|netbsd|openbsd)", compile, "gmake -C c_src"},
+  {"(freebsd|netbsd|openbsd|dragonfly)", compile, "gmake -C c_src"},
   {"(linux|darwin|solaris)",   compile, "make -C c_src"}
 ]}.
 {post_hooks, [
-  {"(freebsd|netbsd|openbsd)", clean, "gmake -C c_src clean"},
+  {"(freebsd|netbsd|openbsd|dragonfly)", clean, "gmake -C c_src clean"},
   {"(linux|darwin|solaris)",   clean, "make -C c_src clean"}
 ]}.
 


### PR DESCRIPTION
* There was a typo in `c_src/Makefile` ("dradonfly")

* "dragonfly" as platform was missing in rebar pre and post hooks