### PR TITLE
feat: allow showing compilation info via env var

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,14 +4,7 @@
 	warn_export_all
 ]}.
 
-{pre_hooks,  [
-  {"(freebsd|netbsd|openbsd|dragonfly)", compile, "gmake -C c_src"},
-  {"(linux|darwin|solaris)",   compile, "make -C c_src"}
-]}.
-{post_hooks, [
-  {"(freebsd|netbsd|openbsd|dragonfly)", clean, "gmake -C c_src clean"},
-  {"(linux|darwin|solaris)",   clean, "make -C c_src clean"}
-]}.
+% `rebar.config.script` has the config for `edoc_opts`, `pre_hooks` and `post_hooks`
 
 {plugins, [rebar3_hex, {rebar3_ex_doc, "0.2.12"}]}.
 {hex, [{doc, ex_doc}]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -2,5 +2,23 @@
 
 Vsn = string:strip(os:cmd("git describe --always --tags --abbrev=0 | sed 's/^v//'"), right, $\n),
 
-maps:to_list(maps:merge(maps:from_list(CONFIG), #{edoc_opts => [{def, {vsn, Vsn}}]})).
+%% Determine optional target suffix
+ExtraTargets =
+  case os:getenv("ERLEXEC_REBAR_COMPILE_INFO") of
+    "1" -> " info all";
+    _   -> ""
+  end,
 
+CONFIG_FINAL = CONFIG ++ [
+  {edoc_opts, [{def, {vsn, Vsn}}]},
+  {pre_hooks, [
+    {"(freebsd|netbsd|openbsd|dragonfly)", compile, "gmake -C c_src" ++ ExtraTargets},
+    {"(linux|darwin|solaris)",             compile, "make -C c_src"  ++ ExtraTargets}
+  ]},
+  {post_hooks, [
+    {"(freebsd|netbsd|openbsd|dragonfly)", clean, "gmake -C c_src clean"},
+    {"(linux|darwin|solaris)",             clean, "make -C c_src clean"}
+  ]}
+],
+
+maps:to_list(maps:from_list(CONFIG_FINAL)).


### PR DESCRIPTION
This PR allows using an env var `ERLEXEC_REBAR_COMPILE_INFO` to execute both Makefile targets `info` and `all` (aka compile) at once, helpful when being compiled from Elixir. Therefore, in case errors like [priv/false*](https://github.com/saleyn/erlexec/issues/185) appear in the future, we can track what was the compilation log, since it just emits 6 lines and can be beneficial to understand the origin of the trouble. In the end, it is optional.

* "priv/false" or any error like `:failed_to_start_child, :exec, {:bad_return_value...` indicating the exec-port is not found/available.

For instance, two examples when being executed from Elixir toolchain.

a) while building normally:

```
$ mix do deps.compile erlexec, compile
make: Nothing to be done for `all'.
===> Analyzing applications...
===> Compiling erlexec
==> project
Generated project app
```

b) using this feature:

```
$ ERLEXEC_REBAR_COMPILE_INFO=1 mix do deps.compile erlexec, compile
SOURCES: ei++.cpp exec_impl.cpp exec.cpp
OBJECTS: ei++.o exec_impl.o exec.o
TARGET:  aarch64-apple-darwin
MARCH:   aarch64-apple-darwin
OUTPUT:  /Users/user/project/deps/erlexec/priv/aarch64-apple-darwin/exec-port
OUT_DIR: /Users/user/project/deps/erlexec/priv/aarch64-apple-darwin/
make: Nothing to be done for `all'.
===> Analyzing applications...
===> Compiling erlexec
==> project
Generated project app
```
