### PR TITLE
Fix PTY process-group race on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ priv/*
 priv/test/*
 !priv/test/fake_exec_port.escript
 !priv/test/deny_setpgid.c
+!priv/test/delay_setsid_deny_child_setpgid.c
 !priv/test/exec_port_fork_wrapper.c
 ebin
 .rebar/*

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ The following features are supported:
 * Run interactive processes with psudo-terminal pty support.
 * Support all RFC4254 pty psudo-terminal options defined in
   [section-8](https://datatracker.ietf.org/doc/html/rfc4254#section-8) of the spec.
+  PTY commands use the session/process group created by `setsid()`, so
+  `{group, 0}` remains the equivalent of "own process group" in PTY mode.
 * Execute OS processes under different user credentials (using Linux capabilities).
 * Perform proper cleanup of OS child processes at port program termination time.
 

--- a/c_src/exec.cpp
+++ b/c_src/exec.cpp
@@ -399,8 +399,10 @@ bool process_command(bool is_err)
             if ((pid = start_child(po, err)) < 0)
                 send_error_str(transId, false, "Couldn't start pid: %s", err.c_str());
             else {
+                // PTY children create their own session/process group via setsid().
+                pid_t gid = po.pty_owns_group() ? pid : getpgid(pid);
                 children.emplace(pid, CmdInfo(po.cmd(), po.kill_cmd(), pid,
-                                              getpgid(pid),
+                                              gid,
                                               po.success_exit_code(), false,
                                               po.stream_fd(STDIN_FILENO),
                                               po.stream_fd(STDOUT_FILENO),

--- a/c_src/exec.hpp
+++ b/c_src/exec.hpp
@@ -250,6 +250,9 @@ public:
     const CmdArgsList&   cmd()          const { return m_cmd; }
     bool                 shell()        const { return m_shell; }
     bool                 pty()          const { return m_pty; }
+    bool                 pty_owns_group() const {
+        return m_pty && (m_group == std::numeric_limits<int>::max() || m_group == 0);
+    }
     bool                 pty_echo()     const { return m_pty_echo; }
     MapPtyOpt const&     pty_opts()     const { return m_pty_opts; }
     std::tuple<int, int> winsz()        const { return std::make_tuple(m_winsz_rows, m_winsz_cols); }

--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -658,7 +658,11 @@ pid_t start_child(CmdOptions& op, std::string& error)
         }
         #endif
 
-        if (op.group() != std::numeric_limits<int>::max() && setpgid(0, op.group()) < 0) {
+        // PTY children that own their session/group already got it from setsid().
+        if (!op.pty_owns_group() &&
+            op.group() != std::numeric_limits<int>::max() &&
+            setpgid(0, op.group()) < 0)
+        {
             err.write("Cannot set effective group to %d", op.group());
             perror(err.c_str());
             exit(EXIT_FAILURE);
@@ -735,7 +739,7 @@ pid_t start_child(CmdOptions& op, std::string& error)
     // group ID to the same value immediately after a fork(), and the
     // parent ignores any occurrence of the EACCES error on the setpgid() call.
 
-    if (op.group() != std::numeric_limits<int>::max()) {
+    if (!op.pty_owns_group() && op.group() != std::numeric_limits<int>::max()) {
         pid_t gid = op.group() ? op.group() : pid;
         if (setpgid(pid, gid) == -1 && errno != EACCES)
             DEBUG(debug, "  Parent failed to set group of pid %d to %d: %s",
@@ -1689,4 +1693,3 @@ int CmdOptions::init_cenv()
 }
 
 } // namespace ei
-

--- a/priv/test/delay_setsid_deny_child_setpgid.c
+++ b/priv/test/delay_setsid_deny_child_setpgid.c
@@ -1,0 +1,40 @@
+#define _GNU_SOURCE
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+static pid_t exec_port_pid = -1;
+
+__attribute__((constructor))
+static void remember_exec_port_pid(void)
+{
+    exec_port_pid = getpid();
+}
+
+pid_t setsid(void)
+{
+    static pid_t (*real_setsid)(void) = NULL;
+    if (real_setsid == NULL)
+        real_setsid = (pid_t (*)(void))dlsym(RTLD_NEXT, "setsid");
+
+    if (getpid() != exec_port_pid)
+        usleep(200000);
+
+    return real_setsid();
+}
+
+int setpgid(pid_t pid, pid_t pgid)
+{
+    static int (*real_setpgid)(pid_t, pid_t) = NULL;
+    if (real_setpgid == NULL)
+        real_setpgid = (int (*)(pid_t, pid_t))dlsym(RTLD_NEXT, "setpgid");
+
+    if (getpid() != exec_port_pid) {
+        errno = EPERM;
+        return -1;
+    }
+
+    return real_setpgid(pid, pgid);
+}

--- a/src/exec.erl
+++ b/src/exec.erl
@@ -266,6 +266,8 @@ Command options:
 - `{group, GID}`
   : Sets the effective group ID of the spawned process. The value 0
     means to create a new group ID equal to the OS pid of the process.
+    When `pty` is enabled, omitting `group` or using `{group, 0}` relies on
+    the session/process group created by `setsid()`.
 - `{user, RunAsUser}`
   : When exec-port was compiled with capability (Linux) support
     enabled and has a suid bit set, it's capable of running
@@ -1590,7 +1592,8 @@ exec_test_() ->
             ?tt(test_pty()),
             ?tt(test_pty_echo()),
             ?tt(test_pty_opts()),
-            ?tt(test_dynamic_pty_opts())
+            ?tt(test_dynamic_pty_opts()),
+            ?tt(test_pty_group_zero_kill_group())
         ]
     }.
 
@@ -1980,6 +1983,29 @@ test_dynamic_pty_opts() ->
     ?receiveBytes({stdout, I, <<"^B">>}, 5000),
     ?receivePattern({'DOWN', I, process, P, {exit_status, 2}}, 5000).
 
+test_pty_group_zero_kill_group() ->
+    case build_pty_group_zero_harness() of
+        {ok, PreloadPath} ->
+            PidFile = temp_file(),
+            {ok, ExecPid} = exec:start([{env, [{"LD_PRELOAD", PreloadPath}]}]),
+            try
+                Cmd = lists:flatten(io_lib:format("sleep 20 & echo $! > ~s; wait", [PidFile])),
+                {ok, P, I} = exec:run(Cmd, [monitor, pty, {group, 0}, kill_group]),
+                ChildPid = read_pid_file(PidFile),
+                ok = exec:stop(I),
+                ?receivePattern({'DOWN', I, process, P, normal}, 5000),
+                wait_until_pid_stops(ChildPid)
+            after
+                maybe_kill_pid_from_file(PidFile),
+                file:delete(PidFile),
+                exit(ExecPid, kill)
+            end;
+        {error, Reason} ->
+            erlang:error(Reason);
+        {skip, _Reason} ->
+            ok
+    end.
+
 test_port_runs_in_own_process_group() ->
     {ok, ExecPid} = exec:start([]),
     try
@@ -2223,12 +2249,36 @@ maybe_kill_pid_from_file(Path) ->
             ok
     end.
 
+wait_until_pid_stops(Pid) ->
+    wait_until_pid_stops(Pid, 20).
+
+wait_until_pid_stops(Pid, 0) ->
+    erlang:error({pid_still_running, Pid});
+wait_until_pid_stops(Pid, Retries) ->
+    case os_pid_running(Pid) of
+        false ->
+            ok;
+        true ->
+            timer:sleep(100),
+            wait_until_pid_stops(Pid, Retries - 1)
+    end.
+
 build_setpgid_failure_harness() ->
     case {os:type(), os:find_executable("cc")} of
         {{unix, linux}, false} ->
             {skip, no_c_compiler};
         {{unix, linux}, Cc} ->
             compile_setpgid_failure_harness(Cc);
+        _ ->
+            {skip, unsupported_os}
+    end.
+
+build_pty_group_zero_harness() ->
+    case {os:type(), os:find_executable("cc")} of
+        {{unix, linux}, false} ->
+            {skip, no_c_compiler};
+        {{unix, linux}, Cc} ->
+            compile_pty_group_zero_harness(Cc);
         _ ->
             {skip, unsupported_os}
     end.
@@ -2251,6 +2301,19 @@ compile_setpgid_failure_harness(Cc) ->
         {_, {error, _} = Error} ->
             file:delete(PreloadPath),
             file:delete(WrapperPath),
+            Error
+    end.
+
+compile_pty_group_zero_harness(Cc) ->
+    PrivDir = code:priv_dir(erlexec),
+    Base = integer_to_list(erlang:unique_integer([positive])),
+    PreloadPath = filename:join(PrivDir, "delay_setsid_deny_child_setpgid_" ++ Base ++ ".so"),
+    TestDir = filename:join(PrivDir, "test"),
+    PreloadSource = filename:join(TestDir, "delay_setsid_deny_child_setpgid.c"),
+    case compile_c_helper(Cc, ["-shared", "-fPIC", "-ldl"], PreloadPath, PreloadSource) of
+        ok ->
+            {ok, PreloadPath};
+        {error, _} = Error ->
             Error
     end.
 


### PR DESCRIPTION
## Summary

This fixes a PTY-specific process-group race in `erlexec`.

In PTY mode, the child already creates a fresh session/process group via `setsid()`. However, `erlexec` was still also trying to apply `{group, 0}` via `setpgid()` in both the child and the parent. On Linux this could race and fail with:

```text
Cannot set effective group to 0: Operation not permitted
```

That failure is especially relevant for callers that run PTY commands with `{group, 0}` and `kill_group` so subprocess trees can be cleaned up reliably.

## What changed

- Treat PTY commands with omitted `group` or `{group, 0}` as owning their process group via `setsid()`
- Skip the redundant PTY `setpgid()` path in both child and parent
- Record the PTY child’s group as `pid` instead of racing `getpgid(pid)` immediately after `fork()`
- Document the PTY/group behaviour in the public docs
- Add a Linux-only regression test using an `LD_PRELOAD` harness to make the old race deterministic

## Result

This preserves `kill_group` semantics for PTY subprocess trees while removing the Linux startup race for PTY + `{group, 0}`.

## Verification

Local EUnit passed:

```text
30 tests, 0 failures
```
