### PR TITLE
fix(erlexec): replace deprecated catch in capability validation

### DIFF
--- a/src/exec_util.erl
+++ b/src/exec_util.erl
@@ -126,12 +126,16 @@ validate_capabilities(CapList) when is_list(CapList) ->
                 "cap_" ++ Name -> Name;
                 Other          -> Other
             end,
-        maybe 
-            {ok, ACap} ?= try {ok, erlang:list_to_existing_atom(Cap)}
-                          catch _ -> error
-                          end,
-            Index       = capability_to_index(ACap),
-            true       ?= (Index >= 0)
+        maybe
+            {ok, ACap} ?=
+                try
+                    {ok, erlang:list_to_existing_atom(Cap)}
+                catch
+                    _:_ ->
+                        error
+                end,
+            Index = capability_to_index(ACap),
+            true ?= (Index >= 0)
         else
             _ -> error({invalid_capability, C})
         end

--- a/src/exec_util.erl
+++ b/src/exec_util.erl
@@ -127,15 +127,11 @@ validate_capabilities(CapList) when is_list(CapList) ->
                 Other          -> Other
             end,
         maybe
-            {ok, ACap} ?=
-                try
-                    {ok, erlang:list_to_existing_atom(Cap)}
-                catch
-                    _:_ ->
-                        error
-                end,
-            Index = capability_to_index(ACap),
-            true ?= (Index >= 0)
+            {ok, ACap} ?= try {ok, erlang:list_to_existing_atom(Cap)}
+                          catch _:_ -> error
+                          end,
+            Index       = capability_to_index(ACap),
+            true       ?= (Index >= 0)
         else
             _ -> error({invalid_capability, C})
         end


### PR DESCRIPTION
Replace deprecated Erlang `catch Expr` usage with an explicit `try ... catch ... end` block when validating capabilities.

This preserves the previous invalid-capability fallback behavior while removing the compiler warning.