### PR TITLE
Fix cmd type spec to include `[binary()]`

### DIFF
--- a/src/exec.erl
+++ b/src/exec.erl
@@ -255,7 +255,7 @@ followed by the list of arguments (e.g. `["/bin/echo", "ok"]`).
 In this case all shell-based features are disabled
 and there's no shell injection vulnerability.
 """.
--type cmd() :: binary() | string() | [string()].
+-type cmd() :: binary() | string() | [binary() | string()].
 -export_type([cmd/0]).
 
 -type cmd_options() :: [cmd_option()].

--- a/test/test_exec.erl
+++ b/test/test_exec.erl
@@ -666,6 +666,25 @@ test_child_cap_inheritance_across_exec() ->
     CapCheckCmd = "grep -i '^CapEff' /proc/self/status | wc -l || echo '0'",
     run_command_n_times(CapCheckCmd, 3).
 
+%% Test: Very that that cmd() accepts a list of binaries
+cmd_binary_list_test_() ->
+    {setup,
+     fun() -> application:ensure_all_started(erlexec), ok end,
+     fun(_) -> ok end,
+     [
+         {"run with list of binaries", fun() ->
+             {ok, [{stdout, [Output]}]} =
+                 exec:run([<<"/bin/echo">>, <<"hello">>], [sync, stdout]),
+             ?assertEqual(<<"hello\n">>, Output)
+         end},
+         {"run with mixed binaries and charlists", fun() ->
+             {ok, [{stdout, [Output]}]} =
+                 exec:run(["/bin/echo", <<"world">>], [sync, stdout]),
+             ?assertEqual(<<"world\n">>, Output)
+         end}
+     ]
+    }.
+
 %% Main test suite generator for capability tests
 capabilities_test_() ->
     {setup,


### PR DESCRIPTION
In https://github.com/saleyn/erlexec/commit/673e104 (https://github.com/saleyn/erlexec/issues/91) cmd was updated to support unicode but the typespec was not updated.

This caused Dialyzer to reject `[binary()]` (which is often used in Elixir) causing an inferred `no_return` for callers.