### PR TITLE
Fix exec-port busy-loop on EOF with stale errno (OpenBSD 100% CPU)

### DIFF
--- a/c_src/ei++.cpp
+++ b/c_src/ei++.cpp
@@ -177,9 +177,9 @@ int Serializer::read_exact(int fd, char *buf, size_t len, size_t& got)
 
   while (got < len) {
     int size = len-got;
-    while ((i = ::read(fd, (void*)(buf+got), size)) < size && errno == EINTR)
-      if (i > 0)
-        got += i;
+    do {
+      i = ::read(fd, (void*)(buf+got), size);
+    } while (i < 0 && errno == EINTR);
 
     if (i <= 0)
       return i;
@@ -196,9 +196,9 @@ int Serializer::write_exact(int fd, const char *buf, size_t len, size_t& wrote)
 
   while (wrote < len) {
     int size = len-wrote;
-    while ((i = ::write(fd, buf+wrote, size)) < size && errno == EINTR)
-      if (i > 0)
-        wrote += i;
+    do {
+      i = ::write(fd, buf+wrote, size);
+    } while (i < 0 && errno == EINTR);
 
     if (i <= 0)
       return i;

--- a/c_src/exec_impl.cpp
+++ b/c_src/exec_impl.cpp
@@ -188,7 +188,7 @@ bool process_sigchld()
     DEBUG(debug > 1, "Processed %d SIGCHLD signals from pipe", processed);
   }
 
-  return n > 0 || errno == EAGAIN;
+  return n > 0 || (n < 0 && errno == EAGAIN);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
read_exact()/write_exact() retried the syscall while errno == EINTR, regardless of the actual return value. When poll(2) is interrupted by SIGCHLD it returns -1 with errno=EINTR (on OpenBSD, SA_RESTART does not restart poll). errno is then left stale until the next failing syscall. If the Erlang command pipe subsequently hits EOF, read() returns 0 without clearing errno, so '0 < size && errno == EINTR' stays true and read_exact() spins forever calling read() at 100% CPU. The port program never notices the VM is gone, becomes an orphan reparented to init, and ignores SIGTERM because it never returns to the main loop.

Fix: only retry when the syscall actually failed with -1 and errno is EINTR. Also harden process_sigchld() against consulting a stale errno after a 0-byte read.

Fixed by LLM model: deepseek-v4-flash.